### PR TITLE
Fix: deploy workflow environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [tests-pytest]
+    environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
     permissions:
       packages: write
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [tests-pytest]
+    if: (!cancelled())
     environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
     permissions:
       packages: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,11 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  # this ternary operator like expression gives us the name of the deployment environment (see https://docs.github.com/en/actions/learn-github-actions/expressions#example)
+  group: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
+  cancel-in-progress: true
+
 jobs:
   tests-pytest:
     uses: ./.github/workflows/tests-pytest.yml


### PR DESCRIPTION
Forgot to add the `environment` expression to activate the correct environment:

* `main`
* `test`
* `prod`

These correspond to the repo environments: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/settings/environments

Each environment holds the specific deploy secrets and variables.