### PR TITLE
Feat: static files config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !web/oauth/migrations/sample_fixtures.json
 dist/
 static/
+!web/static
 __pycache__/
 .coverage
 .DS_Store

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -23,6 +23,7 @@
           href="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/css/colortheme-oceanside.css"
           integrity="sha256-PC5Yszm8bAjYYFmjeL8EeB8mHo+S4dJbQt4OwA4aTmg="
           crossorigin="anonymous" />
+    <link rel="stylesheet" href="{% static "css/styles.css" %}">
     <!-- State Template JavaScript CDN -->
     <script src="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/js/cagov.core.js"
             integrity="sha256-TOklMoh1iWoUNIVyzn+Wq8bS56lQWa0R8qklisvEALo="

--- a/web/settings.py
+++ b/web/settings.py
@@ -175,9 +175,19 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
-
-STATIC_URL = "static/"
-
+STATIC_URL = "/static/"
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "web", "static")]
+# use Manifest Static Files Storage by default
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": os.environ.get(
+            "DJANGO_STATICFILES_STORAGE", "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+        )
+    },
+}
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Default primary key field type


### PR DESCRIPTION
- Serve static files from `/static` virtual path (already mapped in `nginx`)
- Configure static files storage to use [ManifestStaticFileStorage](https://docs.djangoproject.com/en/5.1/ref/contrib/staticfiles/#manifeststaticfilesstorage)
- Maintain static files in `web/static/` e.g. `web/static/css/` for CSS files, or `web/static/img/` for static image files
- Placeholder site CSS file at `web/static/css/styles.css` included in `base.html` template