### PR TITLE
Fix: startup and runtime

### DIFF
--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -87,4 +87,4 @@ RUN pip install $(find /build/dist -name ca_disaster_recovery*.whl)
 
 # configure container executable
 ENTRYPOINT ["/bin/bash"]
-CMD ["bin/reset_db.sh"]
+CMD ["bin/start.sh"]

--- a/bin/reset_db.sh
+++ b/bin/reset_db.sh
@@ -31,5 +31,3 @@ if [[ -n "$valid_fixtures" ]]; then
 else
     echo "No JSON fixtures to load"
 fi
-
-bin/start.sh

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -3,7 +3,7 @@ set -eu
 
 # initialize Django
 
-bin/init.sh
+bin/reset_db.sh
 
 # start the web server
 

--- a/web/settings.py
+++ b/web/settings.py
@@ -40,9 +40,9 @@ def RUNTIME_ENVIRONMENT():
     # usage of django.conf.settings.ALLOWED_HOSTS here (rather than the module variable directly)
     # is to ensure dynamic calculation, e.g. for unit tests and elsewhere this setting is needed
     env = RUNTIME_ENVS.LOCAL
-    if "dev.disasterrecovery.ca.gov" in settings.ALLOWED_HOSTS:
+    if "dev" in settings.ALLOWED_HOSTS:
         env = RUNTIME_ENVS.DEV
-    elif "test.disasterrecovery.ca.gov" in settings.ALLOWED_HOSTS:
+    elif "test" in settings.ALLOWED_HOSTS:
         env = RUNTIME_ENVS.TEST
     elif "disasterrecovery.ca.gov" in settings.ALLOWED_HOSTS:
         env = RUNTIME_ENVS.PROD


### PR DESCRIPTION
`bin/start.sh` calls `bin/reset_db.sh` instead of the other way around, so that the devcontainer doesn't break when it starts and calls `bin/reset_db.sh`!

Also relax environment check for `dev`/`test` which is currently failing.