### PR TITLE
Refactor: use class-based views in `vital_records`

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,5 +1,27 @@
+from django.contrib.sessions.middleware import SessionMiddleware
+
+import pytest
+
 from pytest_socket import disable_socket
 
 
 def pytest_runtest_setup():
     disable_socket()
+
+
+@pytest.fixture
+def app_request(rf):
+    """
+    Fixture creates and initializes a new Django request object similar to a real application request.
+    """
+    # create a request for the path, initialize
+    app_request = rf.get("/some/arbitrary/path")
+
+    # https://stackoverflow.com/a/55530933/358804
+    middleware = [SessionMiddleware(lambda x: x)]
+    for m in middleware:
+        m.process_request(app_request)
+
+    app_request.session.save()
+
+    return app_request

--- a/tests/pytest/vital_records/test_views.py
+++ b/tests/pytest/vital_records/test_views.py
@@ -1,0 +1,66 @@
+import pytest
+
+from web.vital_records import views
+from web.vital_records.session import Session
+
+
+@pytest.fixture
+def mock_Session_cls(mocker):
+    session = mocker.Mock(spec=Session)
+    return mocker.patch("web.vital_records.views.Session", return_value=session)
+
+
+class TestIndexView:
+    @pytest.fixture
+    def view(self, app_request):
+        v = views.IndexView()
+        v.setup(app_request)
+        return v
+
+    def test_get_creates_new_session(self, view, app_request, mock_Session_cls):
+        view.get(app_request)
+
+        mock_Session_cls.assert_called_once_with(app_request, reset=True)
+
+    def test_template_name(self, view):
+        assert view.template_name == "vital_records/index.html"
+
+
+class TestRequestView:
+    @pytest.fixture
+    def view(app_request):
+        v = views.RequestView()
+        v.setup(app_request)
+        return v
+
+    def test_get_context_data(self, view, mock_Session_cls):
+        mock_Session_cls.return_value.verified_email = "test@example.com"
+
+        context = view.get_context_data()
+
+        assert context["email"] == "test@example.com"
+
+    def test_template_name(self, view):
+        assert view.template_name == "vital_records/request.html"
+
+
+class TestSubmittedView:
+    @pytest.fixture
+    def view(app_request):
+        v = views.SubmittedView()
+        v.setup(app_request)
+        return v
+
+    def test_template_name(self, view):
+        assert view.template_name == "vital_records/submitted.html"
+
+
+class TestUnverifiedView:
+    @pytest.fixture
+    def view(app_request):
+        v = views.UnverifiedView()
+        v.setup(app_request)
+        return v
+
+    def test_template_name(self, view):
+        assert view.template_name == "vital_records/unverified.html"

--- a/web/vital_records/urls.py
+++ b/web/vital_records/urls.py
@@ -6,8 +6,8 @@ app_name = "vital_records"
 
 # /vital-records
 urlpatterns = [
-    path("", views.index, name="index"),
-    path("request", views.request, name="request"),
-    path("submitted", views.submitted, name="submitted"),
-    path("unverified", views.unverified, name="unverified"),
+    path("", views.IndexView.as_view(), name="index"),
+    path("request", views.RequestView.as_view(), name="request"),
+    path("submitted", views.SubmittedView.as_view(), name="submitted"),
+    path("unverified", views.UnverifiedView.as_view(), name="unverified"),
 ]

--- a/web/vital_records/views.py
+++ b/web/vital_records/views.py
@@ -1,22 +1,32 @@
+from typing import Any
+
 from django.http import HttpRequest
-from django.template.response import TemplateResponse
+from django.views.generic import TemplateView
 
 from web.vital_records.session import Session
 
 
-def index(request: HttpRequest):
-    Session(request, reset=True)
-    return TemplateResponse(request, "vital_records/index.html")
+class IndexView(TemplateView):
+    template_name = "vital_records/index.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs):
+        Session(request, reset=True)
+        return super().get(request, *args, **kwargs)
 
 
-def request(request: HttpRequest):
-    session = Session(request)
-    return TemplateResponse(request, "vital_records/request.html", {"email": session.verified_email})
+class RequestView(TemplateView):
+    template_name = "vital_records/request.html"
+
+    def get_context_data(self, **kwargs) -> dict[str, Any]:
+        session = Session(self.request)
+        context = super().get_context_data(**kwargs)
+        context["email"] = session.verified_email
+        return context
 
 
-def submitted(request: HttpRequest):
-    return TemplateResponse(request, "vital_records/submitted.html")
+class SubmittedView(TemplateView):
+    template_name = "vital_records/submitted.html"
 
 
-def unverified(request: HttpRequest):
-    return TemplateResponse(request, "vital_records/unverified.html")
+class UnverifiedView(TemplateView):
+    template_name = "vital_records/unverified.html"


### PR DESCRIPTION
Closes #45 

Adds tests for each view class as well.

`web.vital_records` was the only app that had view functions defined.

`web.core` doesn't define view functions and already used built-in class-based views: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/core/urls.py