### PR TITLE
Feat: `vital_records` view redirects to OAuth flow

### DIFF
--- a/tests/pytest/vital_records/test_views.py
+++ b/tests/pytest/vital_records/test_views.py
@@ -1,3 +1,5 @@
+from django.urls import reverse
+
 import pytest
 
 from web.vital_records import views
@@ -24,6 +26,26 @@ class TestIndexView:
 
     def test_template_name(self, view):
         assert view.template_name == "vital_records/index.html"
+
+
+@pytest.mark.django_db
+class TestLoginView:
+    @pytest.fixture
+    def view(self, app_request):
+        v = views.LoginView()
+        v.setup(app_request)
+        return v
+
+    def test_get_creates_new_session(self, view, app_request, mock_Session_cls):
+        view.get(app_request)
+
+        mock_Session_cls.assert_called_once_with(app_request, reset=True)
+
+    def test_get_redirects_to_login(self, view, app_request):
+        response = view.get(app_request)
+
+        assert response.status_code == 302
+        assert response.url == reverse("cdt:login")
 
 
 class TestRequestView:

--- a/web/vital_records/urls.py
+++ b/web/vital_records/urls.py
@@ -7,6 +7,7 @@ app_name = "vital_records"
 # /vital-records
 urlpatterns = [
     path("", views.IndexView.as_view(), name="index"),
+    path("login", views.LoginView.as_view(), name="login"),
     path("request", views.RequestView.as_view(), name="request"),
     path("submitted", views.SubmittedView.as_view(), name="submitted"),
     path("unverified", views.UnverifiedView.as_view(), name="unverified"),

--- a/web/vital_records/views.py
+++ b/web/vital_records/views.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 from django.http import HttpRequest
+from django.shortcuts import redirect
+from django.views import View
 from django.views.generic import TemplateView
 
 from web.vital_records.session import Session
@@ -12,6 +14,12 @@ class IndexView(TemplateView):
     def get(self, request: HttpRequest, *args, **kwargs):
         Session(request, reset=True)
         return super().get(request, *args, **kwargs)
+
+
+class LoginView(View):
+    def get(self, request: HttpRequest):
+        Session(request, reset=True)
+        return redirect("cdt:login")
 
 
 class RequestView(TemplateView):


### PR DESCRIPTION
Initializing session as if user had come in through `IndexView`.

Closes #42 

~On top of #48~ 

## Reviewing

1. Check out this branch in the devcontainer
2. Reset your database if needed `bin/reset_db.sh` (you need a valid `vital-records` flow and IdG connection details)
3. Launch the app with `F5`
4. Go to the URL `http://localhost:44370/vital-records/login`
5. Redirect to the Login.gov sandbox, sign in with a disaster-affected sandbox account
6. Redirect back to DDRC, see the expected [`RequestView`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/views.py#L17)