### PR TITLE
Feat: use Azure Container App

### DIFF
--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -1,0 +1,141 @@
+resource "azurerm_container_app_environment" "main" {
+  name                       = "CAE-CDT-PUB-VIP-DDRC-${local.env_letter}-001"
+  location                   = data.azurerm_resource_group.main.location
+  resource_group_name        = data.azurerm_resource_group.main.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_container_app" "web" {
+  name                         = lower("aca-cdt-pub-vip-ddrc-${local.env_letter}-web") # has to be lowercase
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = data.azurerm_resource_group.main.name
+  revision_mode                = "Single"
+  max_inactive_revisions       = 10
+  workload_profile_name        = "Consumption"
+
+  secret {
+    name                = "requests-connect-timeout"
+    key_vault_secret_id = "${local.secret_http_prefix}/requests-connect-timeout"
+    identity            = "System"
+  }
+  secret {
+    name                = "requests-read-timeout"
+    key_vault_secret_id = "${local.secret_http_prefix}/requests-read-timeout"
+    identity            = "System"
+  }
+  secret {
+    name                = "django-allowed-hosts"
+    key_vault_secret_id = "${local.secret_http_prefix}/django-allowed-hosts"
+    identity            = "System"
+  }
+  secret {
+    name                = "django-storage-dir"
+    key_vault_secret_id = "${local.secret_http_prefix}/django-storage-dir"
+    identity            = "System"
+  }
+  secret {
+    name                = "django-debug"
+    key_vault_secret_id = "${local.secret_http_prefix}/django-debug"
+    identity            = "System"
+  }
+  secret {
+    name                = "django-log-level"
+    key_vault_secret_id = "${local.secret_http_prefix}/django-log-level"
+    identity            = "System"
+  }
+  secret {
+    name                = "django-secret-key"
+    key_vault_secret_id = "${local.secret_http_prefix}/django-secret-key"
+    identity            = "System"
+  }
+  secret {
+    name                = "django-trusted-origins"
+    key_vault_secret_id = "${local.secret_http_prefix}/django-trusted-origins"
+    identity            = "System"
+  }
+  secret {
+    name                = "healthcheck-user-agents"
+    key_vault_secret_id = "${local.secret_http_prefix}/healthcheck-user-agents"
+    identity            = "System"
+  }
+
+  template {
+    min_replicas = 1
+    max_replicas = 3
+    http_scale_rule {
+      concurrent_requests = "10"
+      name                = "http-scaler"
+    }
+
+    container {
+      name    = "web"
+      command = []
+      args    = []
+      image   = "ghcr.io/office-of-digital-services/cdt-ods-disaster-recovery:main"
+      cpu     = 0.5
+      memory  = "1Gi"
+      readiness_probe {
+        path      = "/healthcheck"
+        port      = 8000
+        timeout   = 5
+        transport = "HTTP"
+      }
+      # Requests
+      env {
+        name        = "REQUESTS_CONNECT_TIMEOUT"
+        secret_name = "requests-connect-timeout"
+      }
+      env {
+        name        = "REQUESTS_READ_TIMEOUT"
+        secret_name = "requests-read-timeout"
+      }
+      # Django settings
+      env {
+        name        = "DJANGO_ALLOWED_HOSTS"
+        secret_name = "django-allowed-hosts"
+      }
+      env {
+        name        = "DJANGO_STORAGE_DIR"
+        secret_name = "django-storage-dir"
+      }
+      env {
+        name        = "DJANGO_DEBUG"
+        secret_name = local.is_prod ? null : "django-debug"
+      }
+      env {
+        name        = "DJANGO_LOG_LEVEL"
+        secret_name = "django-log-level"
+      }
+      env {
+        name        = "DJANGO_SECRET_KEY"
+        secret_name = "django-secret-key"
+      }
+      env {
+        name        = "DJANGO_TRUSTED_ORIGINS"
+        secret_name = "django-trusted-origins"
+      }
+      env {
+        name        = "HEALTHCHECK_USER_AGENTS"
+        secret_name = local.is_dev ? null : "healthcheck-user-agents"
+      }
+    }
+  }
+
+  ingress {
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+    external_enabled = true
+    target_port      = 8000
+    transport        = "auto"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -75,7 +75,7 @@ resource "azurerm_container_app" "web" {
       name    = "web"
       command = []
       args    = []
-      image   = "ghcr.io/office-of-digital-services/cdt-ods-disaster-recovery:main"
+      image   = "${var.container_registry}/${var.container_repository}:${var.container_tag}"
       cpu     = 0.5
       memory  = "1Gi"
       readiness_probe {

--- a/terraform/environment.tf
+++ b/terraform/environment.tf
@@ -1,11 +1,12 @@
 locals {
-  is_prod             = terraform.workspace == "default"
-  is_test             = terraform.workspace == "test"
-  is_dev              = !(local.is_prod || local.is_test)
-  env_name            = local.is_prod ? "prod" : terraform.workspace
-  env_letter          = upper(substr(local.env_name, 0, 1))
-  hostname            = local.is_prod ? "recovery.cdt.ca.gov" : "${local.env_name}.recovery.cdt.ca.gov"
-  secret_prefix       = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-DDRC-${local.env_letter}-001;SecretName="
+  is_prod            = terraform.workspace == "default"
+  is_test            = terraform.workspace == "test"
+  is_dev             = !(local.is_prod || local.is_test)
+  env_name           = local.is_prod ? "prod" : terraform.workspace
+  env_letter         = upper(substr(local.env_name, 0, 1))
+  hostname           = local.is_prod ? "recovery.cdt.ca.gov" : "${local.env_name}.recovery.cdt.ca.gov"
+  secret_prefix      = "@Microsoft.KeyVault(VaultName=KV-CDT-PUB-DDRC-${local.env_letter}-001;SecretName="
+  secret_http_prefix = "https://KV-CDT-PUB-DDRC-${local.env_letter}-001.vault.azure.net/secrets"
 }
 
 data "azurerm_resource_group" "main" {

--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -50,7 +50,7 @@ steps:
       command: plan
       # wait for lock to be released, in case being used by another pipeline run
       # https://discuss.hashicorp.com/t/terraform-plan-wait-for-lock-to-be-released/6870/2
-      commandOptions: -input=false -lock-timeout=5m
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(image_tag)"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
@@ -67,7 +67,7 @@ steps:
       provider: azurerm
       command: apply
       # (ditto the lock comment above)
-      commandOptions: -input=false -lock-timeout=5m
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(image_tag)"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"

--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -36,9 +36,10 @@ steps:
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
-  - bash: python terraform/pipeline/tag.py
-    displayName: Set tag-type variable
+  - bash: python terraform/pipeline/tags.py
+    displayName: Set env variables
     env:
+      COMMIT_SHA: $(Build.SourceVersion)
       REASON: $(Build.Reason)
       INDIVIDUAL_SOURCE: $(Build.SourceBranchName)
       SOURCE_BRANCH: $(Build.SourceBranch)

--- a/terraform/pipeline/tags.py
+++ b/terraform/pipeline/tags.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+COMMIT_SHA = os.environ["COMMIT_SHA"]
 REASON = os.environ["REASON"]
 # use variable corresponding to tag triggers
 SOURCE = os.environ["INDIVIDUAL_SOURCE"]
@@ -8,20 +9,25 @@ SOURCE = os.environ["INDIVIDUAL_SOURCE"]
 SOURCE_BRANCH = os.environ["SOURCE_BRANCH"]
 IS_TAG = SOURCE_BRANCH.startswith("refs/tags/") is True
 
+tag_type = None
+image_tag = COMMIT_SHA
+
 if REASON == "IndividualCI" and IS_TAG:
     if re.fullmatch(r"20\d\d.\d\d.\d+-rc\d+", SOURCE):
         tag_type = "test"
     elif re.fullmatch(r"20\d\d.\d\d.\d+", SOURCE):
         tag_type = "prod"
-    else:
-        tag_type = None
 else:
-    tag_type = None
+    # we haven't deployed a new image tag yet, use the main branch
+    image_tag = "main"
 
 print(f"REASON: {REASON}")
 print(f"INDIVIDUAL_SOURCE: {SOURCE}")
 print(f"SOURCE_BRANCH: {SOURCE_BRANCH}")
-print(f"Tag type: {tag_type}")
+print(f"COMMIT_SHA: {COMMIT_SHA}")
+print(f"image_tag: {image_tag}")
+print(f"tag_type: {tag_type}")
 
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash#about-tasksetvariable
+print(f"##vso[task.setvariable variable=image_tag]{image_tag}")
 print(f"##vso[task.setvariable variable=tag_type]{tag_type}")

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,3 +15,21 @@ variable "ENGINEERING_GROUP_OBJECT_ID" {
   description = "Object ID for the DDRC engineering Active Directory Group"
   type        = string
 }
+
+variable "container_registry" {
+  type        = string
+  description = "The name of the container registry (e.g., 'ghcr.io')"
+  default     = "ghcr.io"
+}
+
+variable "container_repository" {
+  type        = string
+  description = "The repository path within the registry"
+  default     = "office-of-digital-services/cdt-ods-disaster-recovery"
+}
+
+variable "container_tag" {
+  type        = string
+  description = "The tag of the container image (e.g. 'main', '2025.04.08-rc1', '2025.05.4')"
+  default     = "main"
+}


### PR DESCRIPTION
Closes #67

Defines a new [Container App](https://learn.microsoft.com/en-us/azure/container-apps/overview) resource via Terraform for the main web app. 

The `image:tag` to comes from variables that are derived from branch/tag metadata during the deploy pipeline run.

This does not yet replace the existing `azurerm_linux_web_app` definition or deployment (e.g. for the existing POC site).