### PR TITLE
Footer: Simplify footer

### DIFF
--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -216,9 +216,6 @@
             <li>
               <a href="{% url 'core:index' %}">Accessibility</a>
             </li>
-            <li>
-              <a href="{% url 'core:index' %}">Website accessibility certification</a>
-            </li>
           </ul>
           <ul class="socialsharer-container">
             <li>

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -199,52 +199,6 @@
       </div>
     </div>
     <!-- global footer goes here -->
-    <aside class="p-b-md p-t-sm section-standout site-footer">
-      <div class="container">
-        <div class="row">
-          <div class="col-md-4">
-            <div class="h4 w-100 brd-bottom brd-highlight p-b"
-                 role="heading"
-                 aria-level="2">About</div>
-            <a href="../about/index.html"
-               class="d-block no-underline m-y font-size-16">
-              About <span class="sr-only">our organization</span>
-            </a>
-            <a href="../about/news/index.html"
-               class="d-block no-underline m-y font-size-16">
-              News <span class="sr-only">from our organization</span>
-            </a>
-            <a href="../about/careers.html"
-               class="d-block no-underline m-y font-size-16">
-              Careers <span class="sr-only">and job openings</span>
-            </a>
-            <a href="../contact.html" class="d-block no-underline m-y font-size-16">Contact us</a>
-          </div>
-          <div class="col-md-4">
-            <div class="h4 w-100 brd-bottom brd-highlight p-b"
-                 role="heading"
-                 aria-level="2">Heading</div>
-            <a href="javascript:;" class="d-block no-underline m-y font-size-16">Link 1</a>
-            <a href="javascript:;" class="d-block no-underline m-y font-size-16">Link 2</a>
-            <a href="javascript:;" class="d-block no-underline m-y font-size-16">Link 3</a>
-          </div>
-          <div class="col-md-4">
-            <div class="h4 w-100 brd-bottom brd-highlight p-b"
-                 role="heading"
-                 aria-level="2">Heading</div>
-            <a href="javascript:;" class="d-block no-underline m-y font-size-16">
-              Link 1 <span class="sr-only">regarding this website</span>
-            </a>
-            <a href="javascript:;" class="d-block no-underline m-y font-size-16">
-              Link 2 <span class="sr-only">regarding this website</span>
-            </a>
-            <a href="javascript:;" class="d-block no-underline m-y font-size-16">
-              Link 3 <span class="sr-only">regarding this website</span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </aside>
     <footer id="footer" class="global-footer">
       <div class="container">
         <div class="d-flex">


### PR DESCRIPTION
closes #65 

Segacy recently updated the footer to be more simple - removing the tall top portion of it. This PR achieves that layout for all pages. This PR also removes the web accessibility certification link, as it is not in the Figma designs.

![image](https://github.com/user-attachments/assets/670abd5a-fa4f-47d5-8f93-9d1750804875)
