### PR TITLE
Fix: resolve InvalidContainerAppWorkloadProfileName error

### DIFF
--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -15,7 +15,6 @@ resource "azurerm_container_app" "web" {
   resource_group_name          = data.azurerm_resource_group.main.name
   revision_mode                = "Single"
   max_inactive_revisions       = 10
-  workload_profile_name        = "Consumption"
 
   secret {
     name                = "requests-connect-timeout"


### PR DESCRIPTION
Follow up to #64 

See failed [`terraform apply`](https://calenterprise.visualstudio.com/CDT.ODS.DDRC/_build/results?buildId=78826&view=logs&j=e2b2897c-f736-5615-5c9c-c20ddcd4aa73&t=ce99383a-5c73-5e0e-b029-4934b8ac07e5&l=396).