### PR TITLE
Fix: Container app pipeline deployment

### DIFF
--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -62,6 +62,16 @@ resource "azurerm_container_app" "web" {
     identity            = "System"
   }
 
+  ingress {
+    external_enabled = true
+    target_port      = 8000
+    transport        = "auto"
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+
   template {
     min_replicas = 1
     max_replicas = 3
@@ -122,16 +132,6 @@ resource "azurerm_container_app" "web" {
         secret_name = local.is_dev ? null : "healthcheck-user-agents"
       }
     }
-  }
-
-  ingress {
-    traffic_weight {
-      percentage      = 100
-      latest_revision = true
-    }
-    external_enabled = true
-    target_port      = 8000
-    transport        = "auto"
   }
 
   lifecycle {

--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -87,12 +87,7 @@ resource "azurerm_container_app" "web" {
       image   = "${var.container_registry}/${var.container_repository}:${var.container_tag}"
       cpu     = 0.5
       memory  = "1Gi"
-      readiness_probe {
-        path      = "/healthcheck"
-        port      = 8000
-        timeout   = 5
-        transport = "HTTP"
-      }
+
       # Requests
       env {
         name        = "REQUESTS_CONNECT_TIMEOUT"

--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -50,7 +50,7 @@ steps:
       command: plan
       # wait for lock to be released, in case being used by another pipeline run
       # https://discuss.hashicorp.com/t/terraform-plan-wait-for-lock-to-be-released/6870/2
-      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(image_tag)"
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
@@ -67,7 +67,7 @@ steps:
       provider: azurerm
       command: apply
       # (ditto the lock comment above)
-      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(image_tag)"
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"

--- a/terraform/pipeline/tags.py
+++ b/terraform/pipeline/tags.py
@@ -10,24 +10,19 @@ SOURCE_BRANCH = os.environ["SOURCE_BRANCH"]
 IS_TAG = SOURCE_BRANCH.startswith("refs/tags/") is True
 
 tag_type = None
-image_tag = COMMIT_SHA
 
 if REASON == "IndividualCI" and IS_TAG:
     if re.fullmatch(r"20\d\d.\d\d.\d+-rc\d+", SOURCE):
         tag_type = "test"
     elif re.fullmatch(r"20\d\d.\d\d.\d+", SOURCE):
         tag_type = "prod"
-else:
-    # we haven't deployed a new image tag yet, use the main branch
-    image_tag = "main"
 
 print(f"REASON: {REASON}")
 print(f"INDIVIDUAL_SOURCE: {SOURCE}")
 print(f"SOURCE_BRANCH: {SOURCE_BRANCH}")
 print(f"COMMIT_SHA: {COMMIT_SHA}")
-print(f"image_tag: {image_tag}")
 print(f"tag_type: {tag_type}")
 
 # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash#about-tasksetvariable
-print(f"##vso[task.setvariable variable=image_tag]{image_tag}")
+print(f"##vso[task.setvariable variable=container_tag]{COMMIT_SHA}")
 print(f"##vso[task.setvariable variable=tag_type]{tag_type}")


### PR DESCRIPTION
Follow up to #64 

The most recent [`terraform apply`](https://calenterprise.visualstudio.com/CDT.ODS.DDRC/_build/results?buildId=78831&view=logs&j=e2b2897c-f736-5615-5c9c-c20ddcd4aa73&t=ce99383a-5c73-5e0e-b029-4934b8ac07e5) timed out after about 20 minutes of trying to deploy the container app.

When I created this through the UI, I didn't use a readiness probe or anything else, so removing that here.

Also fixing the deploy pipeline to always send the commit SHA as an input variable to `plan/apply`, rather than sometimes using `main`. This could cause problems for our `dev` environment where it doesn't actually get redeployed / a new instance. 