### PR TITLE
Fix: Terraform container app definition

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -3,6 +3,10 @@
 # Local .terraform directories
 **/.terraform/*
 
+# .tfplan files
+*.tfplan
+*.tfplan.*
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -63,9 +63,11 @@ resource "azurerm_container_app" "web" {
   }
 
   ingress {
-    external_enabled = true
-    target_port      = 8000
-    transport        = "auto"
+    client_certificate_mode = "ignore"
+    external_enabled        = true
+
+    target_port = 8000
+    transport   = "auto"
     traffic_weight {
       percentage      = 100
       latest_revision = true

--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -16,6 +16,11 @@ resource "azurerm_container_app" "web" {
   revision_mode                = "Single"
   max_inactive_revisions       = 10
 
+  identity {
+    identity_ids = []
+    type         = "SystemAssigned"
+  }
+
   secret {
     name                = "requests-connect-timeout"
     key_vault_secret_id = "${local.secret_http_prefix}/requests-connect-timeout"

--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -22,16 +22,6 @@ resource "azurerm_container_app" "web" {
   }
 
   secret {
-    name                = "requests-connect-timeout"
-    key_vault_secret_id = "${local.secret_http_prefix}/requests-connect-timeout"
-    identity            = "System"
-  }
-  secret {
-    name                = "requests-read-timeout"
-    key_vault_secret_id = "${local.secret_http_prefix}/requests-read-timeout"
-    identity            = "System"
-  }
-  secret {
     name                = "django-allowed-hosts"
     key_vault_secret_id = "${local.secret_http_prefix}/django-allowed-hosts"
     identity            = "System"
@@ -59,11 +49,6 @@ resource "azurerm_container_app" "web" {
   secret {
     name                = "django-trusted-origins"
     key_vault_secret_id = "${local.secret_http_prefix}/django-trusted-origins"
-    identity            = "System"
-  }
-  secret {
-    name                = "healthcheck-user-agents"
-    key_vault_secret_id = "${local.secret_http_prefix}/healthcheck-user-agents"
     identity            = "System"
   }
 
@@ -97,12 +82,12 @@ resource "azurerm_container_app" "web" {
 
       # Requests
       env {
-        name        = "REQUESTS_CONNECT_TIMEOUT"
-        secret_name = "requests-connect-timeout"
+        name  = "REQUESTS_CONNECT_TIMEOUT"
+        value = "5"
       }
       env {
-        name        = "REQUESTS_READ_TIMEOUT"
-        secret_name = "requests-read-timeout"
+        name  = "REQUESTS_READ_TIMEOUT"
+        value = "20"
       }
       # Django settings
       env {
@@ -116,6 +101,7 @@ resource "azurerm_container_app" "web" {
       env {
         name        = "DJANGO_DEBUG"
         secret_name = local.is_prod ? null : "django-debug"
+        value       = local.is_prod ? "False" : null
       }
       env {
         name        = "DJANGO_LOG_LEVEL"
@@ -128,10 +114,6 @@ resource "azurerm_container_app" "web" {
       env {
         name        = "DJANGO_TRUSTED_ORIGINS"
         secret_name = "django-trusted-origins"
-      }
-      env {
-        name        = "HEALTHCHECK_USER_AGENTS"
-        secret_name = local.is_dev ? null : "healthcheck-user-agents"
       }
     }
   }

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -20,7 +20,7 @@ terraform init -upgrade -backend-config="subscription_id=$PROD_ID"
 if [ "$ENV" = "prod" ]; then
   terraform workspace select default
 else
-  terraform workspace select "$ENV"
+  terraform workspace select -or-create "$ENV"
 fi
 
 echo "Setting the subscription for the Azure CLI..."

--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -76,6 +76,12 @@ resource "azurerm_key_vault" "main" {
 
     secret_permissions = ["Get"]
   }
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_container_app.web.identity.0.principal_id
+
+    secret_permissions = ["Get"]
+  }
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
- enable `SystemAssigned` Identity
- policy for access to Key Vault for secrets
- small cleanups to normalize  with existing state

Part of https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/issues/46