### PR TITLE
Base template for form pages

### DIFF
--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -61,7 +61,7 @@
     <!-- END Google Tag Manager -->
   </head>
   <body class="primary">
-    <header role="banner" id="header" class="global-header">
+    <header role="banner" id="header" class="global-header border-0">
       <div id="skip-to-content">
         <a href="#main-content">Skip to Main Content</a>
       </div>
@@ -94,7 +94,7 @@
         </div>
       </div>
       <!-- Site header (branding) structural component -->
-      <div class="section-default">
+      <div class="section-default border-0">
         <div class="branding">
           <div class="header-organization-banner">
             <a href="{% url 'core:index' %}">
@@ -109,12 +109,23 @@
       </div>
     </header>
     <div id="main-content" class="main-content">
-      <div class="container">
-        <main class="main-primary">
-          <h1>
+      <div class="p-t-md bg-primary">
+        <div class="container">
+          <nav aria-label="You are here" class="breadcrumbs">
+            <ol>
+              <li>
+                <a href="/" title="Home page">< Go back to vital records home</a>
+              </li>
+            </ol>
+          </nav>
+          <h1 class="m-t-0 p-b-lg">
             {% block headline %}
             {% endblock headline %}
           </h1>
+        </div>
+      </div>
+      <div class="container">
+        <main class="main-primary">
           {% block inner-content %}
           {% endblock inner-content %}
         </main>

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -90,40 +90,6 @@
                 </div>
               </div>
             </div>
-            <div class="settings-links ms-auto align-items-start pt-2">
-              <a href="{% url 'core:index' %}"
-                 class="m-l-0 underline cursor-pointer"
-                 lang="es"
-                 hreflang="es"
-                 translate="no"
-                 rel="alternate">Español</a>
-              <a href="{% url 'core:index' %}"
-                 lang="ko"
-                 hreflang="ko"
-                 translate="no"
-                 rel="alternate"
-                 class="underline cursor-pointer">한국어</a>
-              <a href="{% url 'core:index' %}"
-                 lang="tl"
-                 hreflang="tl"
-                 translate="no"
-                 rel="alternate"
-                 class="underline cursor-pointer">Tagalog</a>
-              <a href="{% url 'core:index' %}"
-                 lang="vi"
-                 hreflang="vi"
-                 translate="no"
-                 rel="alternate"
-                 class="underline cursor-pointer">Tiếng Việt</a>
-              <a href="{% url 'core:index' %}"
-                 lang="zh-hant"
-                 hreflang="zh-hant"
-                 translate="no"
-                 rel="alternate"
-                 class="underline cursor-pointer">繁體中文</a>
-              <a class="translate notranslate pos-rel top-minus-2"
-                 href="https:www.ca.gov/translate/"><span class="ca-gov-icon-globe" aria-hidden="true"></span><span class="sr-only">Translate</span></a>
-            </div>
           </div>
         </div>
       </div>
@@ -140,50 +106,6 @@
             </a>
           </div>
         </div>
-      </div>
-      <!-- mobile navigation controls -->
-      <div class="mobile-controls">
-        <span class="mobile-control-group mobile-header-icons">
-          <!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
-        </span>
-        <div class="mobile-control-group main-nav-icons">
-          <button id="nav-icon3"
-                  type="button"
-                  class="mobile-control toggle-menu"
-                  aria-expanded="false"
-                  aria-controls="navigation">
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-            <span class="sr-only">Menu</span>
-          </button>
-        </div>
-      </div>
-      <div class="navigation-search full-width-nav container">
-        <div id="head-search" class="search-container featured-search">
-          <div class="d-block d-lg-none">
-            <a href="{% url 'core:index' %}"
-               class="drawer-logo-link first-level-link">
-              <img src="https://cdn.cdt.ca.gov/cdt/cagov/cagov-lockup/cagov-lockup-flag/cagov-lockup-flag-gradient/cagov-lockup-flag-gradient.svg"
-                   alt="CA.gov official logo"
-                   class="drawer-logo mb-4" />
-            </a>
-          </div>
-        </div>
-        <!-- navigation types -->
-        <nav id="navigation"
-             class="main-navigation dropdown"
-             aria-label="Main navigation">
-          <ul id="nav_list" class="top-level-nav">
-            <li class="nav-item">
-              <a class="first-level-link" href="{% url 'core:index' %}">Home</a>
-            </li>
-            <li class="nav-item">
-              <a class="first-level-link" href="{% url 'vital_records:index' %}">Vital records</a>
-            </li>
-          </ul>
-        </nav>
       </div>
     </header>
     <div id="main-content" class="main-content">

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -61,7 +61,7 @@
     <!-- END Google Tag Manager -->
   </head>
   <body class="primary">
-    <header role="banner" id="header" class="global-header fixed">
+    <header role="banner" id="header" class="global-header">
       <div id="skip-to-content">
         <a href="#main-content">Skip to Main Content</a>
       </div>

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -1,40 +1,40 @@
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>California Digital Disaster Recovery Center</title>
-    <meta name="Author" content="State of California" />
-    <meta name="Description" content="State of California" />
-    <meta name="Keywords" content="California, government" />
-    <meta name="viewport"
-          content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <!-- Public Sans font google API -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,100..900;1,100..900&display=block" />
-    <!-- State Template CDN CSS -->
-    <link rel="stylesheet"
-          href="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/css/cagov.core.css"
-          integrity="sha256-OGe4kV30/3p8qPhmiORxFvLS/NrPhdifrumYA6W5W5k="
-          crossorigin="anonymous" />
-    <link rel="stylesheet"
-          href="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/css/colortheme-oceanside.css"
-          integrity="sha256-PC5Yszm8bAjYYFmjeL8EeB8mHo+S4dJbQt4OwA4aTmg="
-          crossorigin="anonymous" />
-    <link rel="stylesheet" href="{% static "css/styles.css" %}">
-    <!-- State Template JavaScript CDN -->
-    <script src="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/js/cagov.core.js"
-            integrity="sha256-TOklMoh1iWoUNIVyzn+Wq8bS56lQWa0R8qklisvEALo="
-            defer
-            crossorigin="anonymous"></script>
-    <!-- Statewide Alerts Server -->
-    <script defer src="https://alert.cdt.ca.gov" crossorigin="anonymous"></script>
-    <!-- BEGIN Google Tag Manager -->
-    <link rel="preconnect" href="https://www.googletagmanager.com" />
-    <link rel="preconnect" href="https://www.google-analytics.com" />
-    <script>
+    <head>
+        <meta charset="utf-8" />
+        <title>California Digital Disaster Recovery Center</title>
+        <meta name="Author" content="State of California" />
+        <meta name="Description" content="State of California" />
+        <meta name="Keywords" content="California, government" />
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <!-- Public Sans font google API -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link rel="stylesheet"
+              href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,100..900;1,100..900&display=block" />
+        <!-- State Template CDN CSS -->
+        <link rel="stylesheet"
+              href="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/css/cagov.core.css"
+              integrity="sha256-OGe4kV30/3p8qPhmiORxFvLS/NrPhdifrumYA6W5W5k="
+              crossorigin="anonymous" />
+        <link rel="stylesheet"
+              href="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/css/colortheme-oceanside.css"
+              integrity="sha256-PC5Yszm8bAjYYFmjeL8EeB8mHo+S4dJbQt4OwA4aTmg="
+              crossorigin="anonymous" />
+        <link rel="stylesheet" href="{% static "css/styles.css" %}">
+        <!-- State Template JavaScript CDN -->
+        <script src="https://cdn.cdt.ca.gov/cdt/statetemplate/6.4.1/js/cagov.core.js"
+                integrity="sha256-TOklMoh1iWoUNIVyzn+Wq8bS56lQWa0R8qklisvEALo="
+                defer
+                crossorigin="anonymous"></script>
+        <!-- Statewide Alerts Server -->
+        <script defer src="https://alert.cdt.ca.gov" crossorigin="anonymous"></script>
+        <!-- BEGIN Google Tag Manager -->
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
+        <link rel="preconnect" href="https://www.google-analytics.com" />
+        <script>
       //*** BEGIN STATE TEMPLATE CHANGE REQUESTED
       //Your GA4 Measurement ID that this website should use for website analytics
       var yourGA4MeasurementId = "G-75V2BNQ3DR"; //Set to the default GA4 Measurement ID (G-75V2BNQ3D...R), please change it to the one for your organization.
@@ -57,128 +57,115 @@
           cookie_flags: "secure;samesite=lax;domain=",
         });
       })(window, document, "script", "dataLayer", stateGTMAccount);
-    </script>
-    <!-- END Google Tag Manager -->
-  </head>
-  <body class="primary">
-    <header role="banner" id="header" class="global-header border-0">
-      <div id="skip-to-content">
-        <a href="#main-content">Skip to Main Content</a>
-      </div>
-      <!-- Utility header structural component -->
-      <div class="utility-header" data-nosnippet>
-        <div class="container">
-          <div class="flex-row">
-            <div class="social-media-links align-items-start">
-              <div class="official-collapsible-content">
-                <button type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapseOficial"
-                        aria-expanded="false"
-                        aria-controls="collapseOficial"
-                        class="btn-official mt-1 gray-900 color-black-hover">
-                  <span class="underline">Official California website</span>
-                  <span class="ca-gov-icon-caret-up" aria-hidden="true"></span>
-                  <span class="ca-gov-icon-caret-down" aria-hidden="true"></span>
-                </button>
-                <div class="collapse" id="collapseOficial">
-                  <div class="font-size-13 gray-900 p-y ps-1 pe-2">
-                    <span class="bold">California government websites use .ca.gov</span>
-                    <br />
-                    A .ca.gov website is part of California’s government.
-                  </div>
-                </div>
-              </div>
+        </script>
+        <!-- END Google Tag Manager -->
+    </head>
+    <body class="primary">
+        <header role="banner" id="header" class="global-header border-0">
+            <div id="skip-to-content">
+                <a href="#main-content">Skip to Main Content</a>
             </div>
-          </div>
-        </div>
-      </div>
-      <!-- Site header (branding) structural component -->
-      <div class="section-default border-0">
-        <div class="branding">
-          <div class="header-organization-banner">
-            <a href="{% url 'core:index' %}">
-              <div class="logo-assets">
-                <img src="https://cdn.cdt.ca.gov/cdt/cagov/cagov-lockup/cagov-lockup-flag/cagov-lockup-flag-gradient/cagov-lockup-flag-gradient.svg"
-                     class="logo-img"
-                     alt="CA.gov official logo" />
-              </div>
-            </a>
-          </div>
-        </div>
-      </div>
-    </header>
-    <main id="main-content" class="main-content">
-      <div class="main-header p-t-md bg-primary">
-        <div class="container">
-          <nav aria-label="You are here" class="breadcrumbs">
-            <ol>
-              <li>
-                <a href="#" title="Home page" class="no-underline underline-hover">< Go back to vital records home</a>
-              </li>
-            </ol>
-          </nav>
-          <h1 class="m-t-0 p-b-lg">
-            {% block headline %}
-            {% endblock headline %}
-          </h1>
-        </div>
-      </div>
-      <div class="container">
-        <div class="main-primary">
-          {% block inner-content %}
-          {% endblock inner-content %}
-        </div>
-      </div>
-    </main>
-    <!-- global footer goes here -->
-    <footer id="footer" class="global-footer">
-      <div class="container">
-        <div class="d-flex">
-          <a href="https://ca.gov" class="cagov-logo">
-            <span class="sr-only">CA.gov</span>
-            <span class="ca-gov-logo-svg"></span>
-          </a>
-          <ul class="footer-links">
-            <li>
-              <a href="{% url 'core:index' %}">Conditions of use</a>
-            </li>
-            <li>
-              <a href="{% url 'core:index' %}">Privacy policy</a>
-            </li>
-            <li>
-              <a href="{% url 'core:index' %}">Accessibility</a>
-            </li>
-          </ul>
-          <ul class="socialsharer-container">
-            <li>
-              <a href="https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery">
-                <span class="ca-gov-icon-github" aria-hidden="true"></span>
-                <span class="sr-only">GitHub</span>
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <!-- Accessible, translatable, Copyright Statement -->
-      <div class="copyright">
-        <div class="container text-right">
-          <span aria-hidden="true">©</span>
-          <span id="thisyear">
-            <script>
+            <!-- Utility header structural component -->
+            <div class="utility-header" data-nosnippet>
+                <div class="container">
+                    <div class="flex-row">
+                        <div class="social-media-links align-items-start">
+                            <div class="official-collapsible-content">
+                                <button type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#collapseOficial"
+                                        aria-expanded="false"
+                                        aria-controls="collapseOficial"
+                                        class="btn-official mt-1 gray-900 color-black-hover">
+                                    <span class="underline">Official California website</span>
+                                    <span class="ca-gov-icon-caret-up" aria-hidden="true"></span>
+                                    <span class="ca-gov-icon-caret-down" aria-hidden="true"></span>
+                                </button>
+                                <div class="collapse" id="collapseOficial">
+                                    <div class="font-size-13 gray-900 p-y ps-1 pe-2">
+                                        <span class="bold">California government websites use .ca.gov</span>
+                                        <br />
+                                        A .ca.gov website is part of California’s government.
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- Site header (branding) structural component -->
+            <div class="section-default border-0">
+                <div class="branding">
+                    <div class="header-organization-banner">
+                        <a href="{% url 'core:index' %}">
+                            <div class="logo-assets">
+                                <img src="https://cdn.cdt.ca.gov/cdt/cagov/cagov-lockup/cagov-lockup-flag/cagov-lockup-flag-gradient/cagov-lockup-flag-gradient.svg"
+                                     class="logo-img"
+                                     alt="CA.gov official logo" />
+                            </div>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </header>
+        <main id="main-content" class="main-content">
+            {% block main-content %}
+                <div class="container">
+                    <div class="main-primary">
+                        {% block inner-content %}
+                        {% endblock inner-content %}
+                    </div>
+                </div>
+            {% endblock main-content %}
+        </main>
+        <!-- global footer goes here -->
+        <footer id="footer" class="global-footer">
+            <div class="container">
+                <div class="d-flex">
+                    <a href="https://ca.gov" class="cagov-logo">
+                        <span class="sr-only">CA.gov</span>
+                        <span class="ca-gov-logo-svg"></span>
+                    </a>
+                    <ul class="footer-links">
+                        <li>
+                            <a href="{% url 'core:index' %}">Conditions of use</a>
+                        </li>
+                        <li>
+                            <a href="{% url 'core:index' %}">Privacy policy</a>
+                        </li>
+                        <li>
+                            <a href="{% url 'core:index' %}">Accessibility</a>
+                        </li>
+                    </ul>
+                    <ul class="socialsharer-container">
+                        <li>
+                            <a href="https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery">
+                                <span class="ca-gov-icon-github" aria-hidden="true"></span>
+                                <span class="sr-only">GitHub</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <!-- Accessible, translatable, Copyright Statement -->
+            <div class="copyright">
+                <div class="container text-right">
+                    <span aria-hidden="true">©</span>
+                    <span id="thisyear">
+                        <script>
               document
                 .getElementById("thisyear")
                 .appendChild(document.createTextNode(new Date().getFullYear()));
-            </script>
-          </span>
-          State of California
-        </div>
-      </div>
-      <button class="return-top">
-        <span class="sr-only">Back to top</span>
-      </button>
-    </footer>
-    <!-- Extra Decorative Content -->
-    <div class="decoration-last">&nbsp;</div>
-  </body>
+                        </script>
+                    </span>
+                    State of California
+                </div>
+            </div>
+            <button class="return-top">
+                <span class="sr-only">Back to top</span>
+            </button>
+        </footer>
+        <!-- Extra Decorative Content -->
+        <div class="decoration-last">&nbsp;</div>
+    </body>
 </html>

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -108,8 +108,8 @@
         </div>
       </div>
     </header>
-    <div id="main-content" class="main-content">
-      <div class="p-t-md bg-primary">
+    <main id="main-content" class="main-content">
+      <div class="main-header p-t-md bg-primary">
         <div class="container">
           <nav aria-label="You are here" class="breadcrumbs">
             <ol>
@@ -125,12 +125,12 @@
         </div>
       </div>
       <div class="container">
-        <main class="main-primary">
+        <div class="main-primary">
           {% block inner-content %}
           {% endblock inner-content %}
-        </main>
+        </div>
       </div>
-    </div>
+    </main>
     <!-- global footer goes here -->
     <footer id="footer" class="global-footer">
       <div class="container">

--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -114,7 +114,7 @@
           <nav aria-label="You are here" class="breadcrumbs">
             <ol>
               <li>
-                <a href="/" title="Home page">< Go back to vital records home</a>
+                <a href="#" title="Home page" class="no-underline underline-hover">< Go back to vital records home</a>
               </li>
             </ol>
           </nav>

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -126,20 +126,4 @@ header {
       }
     }
   }
-  > div.mobile-controls > div.main-nav-icons {
-    top: -5rem;
-    > button.toggle-menu {
-      margin-top: 1rem;
-    }
-  }
-  > div.navigation-search {
-    > div.search-container > div.d-block > a.drawer-logo-link {
-      outline-offset: -3px;
-      > img.drawer-logo {
-        width: 232px;
-        filter: brightness(0) invert(1);
-        aspect-ratio: 18/5;
-      }
-    }
-  }
 }

--- a/web/vital_records/templates/vital_records/base.html
+++ b/web/vital_records/templates/vital_records/base.html
@@ -1,0 +1,30 @@
+{% extends "core/base.html" %}
+{% load i18n %}
+{% block title %}
+  {% translate "Replacement birth record" %}
+{% endblock title %}
+{% block main-content %}
+  <div class="main-header p-t-md bg-primary">
+    <div class="container">
+      <nav aria-label="You are here" class="breadcrumbs">
+        <ol>
+          <li>
+            {% comment %} This is a placeholder link for now {% endcomment %}
+            <a href="/vital-records/request" class="no-underline underline-hover">< Go back to vital records home</a>
+          </li>
+        </ol>
+      </nav>
+      <h1 class="m-t-0 p-b-lg">
+        {% block headline %}
+          {% translate "Replacement birth record" %}
+        {% endblock headline %}
+      </h1>
+    </div>
+  </div>
+  <div class="container">
+    <div class="main-primary">
+      {% block inner-content %}
+      {% endblock inner-content %}
+    </div>
+  </div>
+{% endblock main-content %}

--- a/web/vital_records/templates/vital_records/index.html
+++ b/web/vital_records/templates/vital_records/index.html
@@ -1,11 +1,5 @@
-{% extends "core/base.html" %}
+{% extends "vital_records/base.html" %}
 {% load i18n %}
-{% block title %}
-    {% translate "Request vital records" %}
-{% endblock title %}
-{% block headline %}
-    {% translate "Request vital records" %}
-{% endblock headline %}
 {% block inner-content %}
     <p>{% translate "Here you can request copies of your vital records." %}</p>
     <p>

--- a/web/vital_records/templates/vital_records/request.html
+++ b/web/vital_records/templates/vital_records/request.html
@@ -1,11 +1,4 @@
-{% extends "core/base.html" %}
-{% load i18n %}
-{% block title %}
-    {% translate "Request vital records: Verified" %}
-{% endblock title %}
-{% block headline %}
-    {% translate "Request vital records: Verified" %}
-{% endblock headline %}
+{% extends "vital_records/base.html" %}
 {% block inner-content %}
     <p>You are in a confirmed disaster affected area.</p>
     <p>

--- a/web/vital_records/templates/vital_records/submitted.html
+++ b/web/vital_records/templates/vital_records/submitted.html
@@ -1,11 +1,5 @@
-{% extends "core/base.html" %}
+{% extends "vital_records/base.html" %}
 {% load i18n %}
-{% block title %}
-    {% translate "Request vital records: Complete" %}
-{% endblock title %}
-{% block headline %}
-    {% translate "Request vital records: Complete" %}
-{% endblock headline %}
 {% block inner-content %}
     <p>{% translate "Your request has been submitted." %}</p>
     <p>

--- a/web/vital_records/templates/vital_records/unverified.html
+++ b/web/vital_records/templates/vital_records/unverified.html
@@ -1,11 +1,4 @@
-{% extends "core/base.html" %}
-{% load i18n %}
-{% block title %}
-    {% translate "Request vital records: Not verified" %}
-{% endblock title %}
-{% block headline %}
-    {% translate "Request vital records: Not verified" %}
-{% endblock headline %}
+{% extends "vital_records/base.html" %}
 {% block inner-content %}
     <p>{% translate "We could not verify if you are in a disaster affected area." %}</p>
     <p>


### PR DESCRIPTION
closes #53 

![image](https://github.com/user-attachments/assets/f4a5a875-6c74-450e-88e9-a4a3cdd6da57)

## What this PR does
- Removes some unnecessary header elements, as per Figma
- Removes CSS for those unnecessary header elements
- Adds the headline section with breadcrumb link. (Link location to be updated when link is available).

## Code notes
- The header section is taken from here: https://office-of-digital-services.github.io/California-State-Web-Template-HTML/top-task-1/index.html in the template docs
- Changed the way the `<main>` landmark was wrapping, to ensure a11y rule: all content contained in landmarks

![image](https://github.com/user-attachments/assets/40f5c6a3-4eec-473d-b4a6-cbdf6d1f4752)
