### PR TITLE
CI: login to ADO with PAT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,15 +104,12 @@ jobs:
       contents: read
 
     steps:
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Install/Update Azure DevOps Extension
         run: az extension add --upgrade -y --name azure-devops
+
+      - name: Login to Azure DevOps
+        run: |
+          echo ${{ secrets.ADO_PAT }} | az devops login --organization ${{ secrets.ADO_ORG_URL }}
 
       - name: Trigger Azure pipeline
         run: |


### PR DESCRIPTION
Part of #46.

@thekaveman created the PAT in Azure DevOps, and added it as a repository secret here. 

* The PAT expires on: `2025-06-30`
* The PAT has the following scopes: `Build (Read & execute)`

This is a temporary solution until the more permanent Service Principal based approach can be implemented.