### PR TITLE
Fix: remove db `workload_profile_name`

### DIFF
--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -15,7 +15,6 @@ resource "azurerm_container_app" "db" {
   resource_group_name          = data.azurerm_resource_group.main.name
   revision_mode                = "Single"
   max_inactive_revisions       = 10
-  workload_profile_name        = "Consumption"
 
   identity {
     identity_ids = []


### PR DESCRIPTION
Resolves an [error with `terraform apply`](https://calenterprise.visualstudio.com/CDT.ODS.DDRC/_build/results?buildId=79955&view=logs&j=e2b2897c-f736-5615-5c9c-c20ddcd4aa73&t=09e3679b-5c35-5ae5-373d-72495af6f723&l=348):

```console
creating Container App (
  Subscription: xxxx
  Resource Group Name: RG-CDT-PUB-VIP-DDRC-D-001
  Container App Name: aca-cdt-pub-vip-ddrc-d-db
):

performing CreateOrUpdate:
unexpected status 400 (400 Bad Request) with error:
InvalidContainerAppWorkloadProfileName:
Cannot specify workload profile name for container app in Consumption Only environment.
```