### PR TITLE
Fix: sslmode=disable for Azure connection

### DIFF
--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -166,11 +166,6 @@ resource "azurerm_container_app" "web" {
     key_vault_secret_id = "${local.secret_http_prefix}/postgres-password"
     identity            = "System"
   }
-  secret {
-    name                = "postgres-options"
-    key_vault_secret_id = "${local.secret_http_prefix}/postgres-options"
-    identity            = "System"
-  }
 
   # external, auto port 8000
   ingress {
@@ -248,10 +243,6 @@ resource "azurerm_container_app" "web" {
         # reference the internal name of the database container app
         value = azurerm_container_app.db.latest_revision_name
       }
-      env {
-        name        = "POSTGRES_OPTIONS"
-        secret_name = "postgres-options"
-      }
     }
 
     container {
@@ -292,10 +283,6 @@ resource "azurerm_container_app" "web" {
         name = "POSTGRES_HOSTNAME"
         # reference the internal name of the database container app
         value = azurerm_container_app.db.latest_revision_name
-      }
-      env {
-        name        = "POSTGRES_OPTIONS"
-        secret_name = "postgres-options"
       }
       env {
         name        = "DJANGO_DEBUG"

--- a/web/settings.py
+++ b/web/settings.py
@@ -5,7 +5,6 @@ For more information on this file, see
 https://docs.djangoproject.com/en/5.1/topics/settings/
 """
 
-import json
 import os
 from pathlib import Path
 
@@ -142,7 +141,6 @@ WSGI_APPLICATION = "web.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
-opts = json.loads(os.environ.get("POSTGRES_OPTIONS", json.dumps({})))
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -152,7 +150,16 @@ DATABASES = {
         "HOST": os.environ.get("POSTGRES_HOSTNAME", "postgres"),
         "PORT": os.environ.get("POSTGRES_PORT", "5432"),
         # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-        "OPTIONS": opts,
+        #
+        # In Azure, the Postgres server is running in a container app inside the same
+        # container app environment as the web container app (Django)
+        #
+        # The Postgres container doesn't allow ingress from the public Internet, only
+        # from within the container app environment, and all traffic stays within Azure
+        # (i.e. doesn't travel over the public Internet)
+        #
+        # The Postgres container is also not setup for SSL connections right now
+        "OPTIONS": {"sslmode": "disable"},
     }
 }
 


### PR DESCRIPTION
Part of #68 

In Azure, the Postgres server is running in a container app inside the same container app environment as the web container app (Django).

The Postgres container doesn't allow ingress from the public Internet, only from within the container app environment, and all traffic stays within Azure (i.e. doesn't travel over the public Internet).

The Postgres container is also not setup for SSL connections right now.