### PR TITLE
Feat: fileshare for web container app

### DIFF
--- a/terraform/container_app.tf
+++ b/terraform/container_app.tf
@@ -240,6 +240,17 @@ resource "azurerm_container_app" "web" {
         name        = "DJANGO_TRUSTED_ORIGINS"
         secret_name = "django-trusted-origins"
       }
+
+      volume_mounts {
+        name = "config"
+        path = "/cdt/app/config"
+      }
+    }
+
+    volume {
+      name         = "config"
+      storage_name = azurerm_storage_share.web.name
+      storage_type = "AzureFile"
     }
   }
 

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -23,3 +23,18 @@ resource "azurerm_storage_account" "main" {
     ignore_changes = [tags]
   }
 }
+
+resource "azurerm_storage_share" "web" {
+  name               = "web"
+  storage_account_id = azurerm_storage_account.main.id
+  quota              = 1
+}
+
+resource "azurerm_container_app_environment_storage" "web" {
+  account_name                 = azurerm_storage_account.main.name
+  access_key                   = azurerm_storage_account.main.primary_access_key
+  access_mode                  = "ReadOnly"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  name                         = azurerm_storage_share.web.name
+  share_name                   = azurerm_storage_share.web.name
+}


### PR DESCRIPTION
Unlike the [original file share that was removed](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/pull/88#issue-3015196543), this one is different in a few ways:

* SMB protocol
* Read-only

It works for mounting in simple static files like fixtures etc.