### PR TITLE
Styles: Style the form progress sidebar

### DIFF
--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -132,6 +132,36 @@ header {
   min-height: calc(100vh - 190px); /* Temporary fix for footer issue */
 }
 
-li[data-status="current"]:before {
-  background: gold; /* Temporary style for form debugging */
+.cagov-step-list.sm {
+  padding-top: 8px;
+}
+
+.cagov-step-list.sm > li[data-status="current"]:before {
+  background-color: #005ea2;
+  border-color: #005ea2;
+  color: #ffffff;
+}
+
+.cagov-step-list.sm > li {
+  border-left-width: 4px;
+  border-color: #e6e6e6;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  padding-left: 40px;
+  padding-bottom: 25px;
+}
+
+.cagov-step-list.sm > li::before {
+  border: 4px solid #e6e6e6;
+  font-size: 14px;
+  width: 32px;
+  height: 32px;
+  left: -18px;
+  top: -8px;
+  line-height: 24px;
+}
+
+.cagov-step-list > li:last-child {
+  padding-left: 45px;
 }

--- a/web/vital_records/templates/vital_records/_form_progress.html
+++ b/web/vital_records/templates/vital_records/_form_progress.html
@@ -1,4 +1,4 @@
-<ol class="cagov-step-list sm">
+<ol class="cagov-step-list sm d-none d-md-block d-lg-block">
     <li data-status="{% if url_name == 'request_name' %}current{% endif %}">Name</li>
     <li data-status="{% if url_name == 'request_county' %}current{% endif %}">County of birth</li>
     <li data-status="{% if url_name == 'request_dob' %}current{% endif %}">Date of birth</li>

--- a/web/vital_records/templates/vital_records/_form_progress.html
+++ b/web/vital_records/templates/vital_records/_form_progress.html
@@ -1,4 +1,4 @@
-<ol class="cagov-step-list">
+<ol class="cagov-step-list sm">
     <li data-status="{% if url_name == 'request_name' %}current{% endif %}">Name</li>
     <li data-status="{% if url_name == 'request_county' %}current{% endif %}">County of birth</li>
     <li data-status="{% if url_name == 'request_dob' %}current{% endif %}">Date of birth</li>


### PR DESCRIPTION
closes #54 

![image](https://github.com/user-attachments/assets/47da39dd-4bf2-441e-94a5-a2fa1767142f)

## Step List, Small size
- Does not show up on mobile
- The steps are not clickable

## CSS approach
- Created a class, called `sm` (as in `small`). Adding this `sm` style to the existing `cagov-step-list` will turn the default list to look like this smaller, more compact list.
- I did NOT add any new CSS variables for colors. This element uses a blue `#005ea2` and a light gray `#e6e6e6`. Both Bootstrap and the CA State Web Template and the color schemes have many blues and grays, so perhaps, after the deadline, we can use an existing blue and gray instead of adding more of our own? Color options: https://template.webstandards.ca.gov/visual-design/color.html
- Not using `rems` yet. I haven't been able to figure out the exact reason.. but during development, I've been seeing 1rem=14px on some pages and 16px on others.