### PR TITLE
Form: Required labels

### DIFF
--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -135,3 +135,8 @@ header {
 li[data-status="current"]:before {
   background: gold; /* Temporary style for form debugging */
 }
+
+abbr[title="required"] {
+  cursor: none;
+  text-decoration: none;
+}

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -136,7 +136,9 @@ li[data-status="current"]:before {
   background: gold; /* Temporary style for form debugging */
 }
 
-abbr[title="required"] {
-  cursor: none;
-  text-decoration: none;
+#vital-records {
+  abbr[title="required"] {
+    cursor: none;
+    text-decoration: none;
+  }
 }

--- a/web/vital_records/templates/vital_records/_two_column_form.html
+++ b/web/vital_records/templates/vital_records/_two_column_form.html
@@ -1,3 +1,4 @@
+{% load form_helpers %}
 <div class="row">
     {% if label %}
         <div class="col-12">
@@ -7,7 +8,7 @@
     {% endif %}
     {% for field in fields %}
         <div class="form-group col-md-6 p-r-md">
-            {{ field.label_tag }}
+            {{ field|label_with_required }}
             {{ field }}
             {% if field.help_text %}<small class="form-help">{{ field.help_text }}</small>{% endif %}
             {% if field.errors %}<div class="form-error">{{ field.errors }}</div>{% endif %}

--- a/web/vital_records/templates/vital_records/base.html
+++ b/web/vital_records/templates/vital_records/base.html
@@ -4,28 +4,30 @@
   {% translate "Replacement birth record" %}
 {% endblock title %}
 {% block main-content %}
-  <div class="main-header p-t-md bg-primary">
-    <div class="container">
-      <nav aria-label="You are here" class="breadcrumbs">
-        <ol>
-          <li>
-            {% comment %} This is a placeholder link for now {% endcomment %}
-            <a href="{% url 'vital_records:request_eligibility' %}"
-               class="no-underline underline-hover">< Go back to vital records home</a>
-          </li>
-        </ol>
-      </nav>
-      <h1 class="m-t-0 p-b-lg">
-        {% block headline %}
-          {% translate "Replacement birth record" %}
-        {% endblock headline %}
-      </h1>
+  <div id="vital-records">
+    <div class="main-header p-t-md bg-primary">
+      <div class="container">
+        <nav aria-label="You are here" class="breadcrumbs">
+          <ol>
+            <li>
+              {% comment %} This is a placeholder link for now {% endcomment %}
+              <a href="{% url 'vital_records:request_eligibility' %}"
+                 class="no-underline underline-hover">< Go back to vital records home</a>
+            </li>
+          </ol>
+        </nav>
+        <h1>
+          {% block headline %}
+            {% translate "Replacement birth record" %}
+          {% endblock headline %}
+        </h1>
+      </div>
     </div>
-  </div>
-  <div class="container">
-    <div class="main-primary">
-      {% block inner-content %}
-      {% endblock inner-content %}
+    <div class="container">
+      <div class="main-primary">
+        {% block inner-content %}
+        {% endblock inner-content %}
+      </div>
     </div>
   </div>
 {% endblock main-content %}

--- a/web/vital_records/templates/vital_records/request/county.html
+++ b/web/vital_records/templates/vital_records/request/county.html
@@ -1,5 +1,6 @@
 {% extends "vital_records/base.html" %}
 {% load i18n %}
+{% load form_helpers %}
 {% block inner-content %}
     <div class="row">
         <div class="col-md-3">
@@ -16,7 +17,9 @@
             <form method="post">
                 <div class="w-50 m-y-md p-y-sm">
                     {% csrf_token %}
-                    {{ form.as_p }}
+                    {{ form.county_of_birth|label_with_required }}
+                    {{ form.county_of_birth }}
+                    {{ form.county_of_birth.errors }}
                 </div>
                 <button type="submit" class="btn btn-primary">Confirm</button>
             </form>

--- a/web/vital_records/templates/vital_records/request/dob.html
+++ b/web/vital_records/templates/vital_records/request/dob.html
@@ -19,14 +19,14 @@
                     {% csrf_token %}
                     <div class="row gap-3">
                         <div class="col-md-2">
-                            {{ form.birth_day|label_with_required }}
-                            {{ form.birth_day }}
-                            {{ form.birth_day.help_text }}
-                        </div>
-                        <div class="col-md-2">
                             {{ form.birth_month|label_with_required }}
                             {{ form.birth_month }}
                             {{ form.birth_month.help_text }}
+                        </div>
+                        <div class="col-md-2">
+                            {{ form.birth_day|label_with_required }}
+                            {{ form.birth_day }}
+                            {{ form.birth_day.help_text }}
                         </div>
                         <div class="col-md-3">
                             {{ form.birth_year|label_with_required }}

--- a/web/vital_records/templates/vital_records/request/dob.html
+++ b/web/vital_records/templates/vital_records/request/dob.html
@@ -1,5 +1,6 @@
 {% extends "vital_records/base.html" %}
 {% load i18n %}
+{% load form_helpers %}
 {% block inner-content %}
     <div class="row">
         <div class="col-md-3">
@@ -16,8 +17,22 @@
                     </legend>
                     <p id="dob-hint">If you’re not sure, enter your approximate date of birth.</p>
                     {% csrf_token %}
-                    <div class="row">
-                        <div class="d-flex gap-2 col-md-6 col-lg-4">{{ form.as_p }}</div>
+                    <div class="row gap-3">
+                        <div class="col-md-2">
+                            {{ form.birth_day|label_with_required }}
+                            {{ form.birth_day }}
+                            {{ form.birth_day.help_text }}
+                        </div>
+                        <div class="col-md-2">
+                            {{ form.birth_month|label_with_required }}
+                            {{ form.birth_month }}
+                            {{ form.birth_month.help_text }}
+                        </div>
+                        <div class="col-md-3">
+                            {{ form.birth_year|label_with_required }}
+                            {{ form.birth_year }}
+                            {{ form.birth_year.help_text }}
+                        </div>
                     </div>
                 </fieldset>
                 <button type="submit" class="btn btn-primary">Confirm</button>

--- a/web/vital_records/templates/vital_records/request/eligibility.html
+++ b/web/vital_records/templates/vital_records/request/eligibility.html
@@ -1,5 +1,6 @@
 {% extends "vital_records/base.html" %}
 {% load i18n %}
+{% load form_helpers %}
 {% block inner-content %}
     <h2 class="m-t-80">You’re eligible for free replacement records</h2>
     <div class="row">
@@ -14,7 +15,9 @@
             <form method="post">
                 <div class="m-y-md p-y-sm">
                     {% csrf_token %}
-                    {{ form.as_p }}
+                    {{ form.fire|label_with_required }}
+                    {{ form.fire }}
+                    {{ form.fire.errors }}
                 </div>
                 <button type="submit" class="btn btn-primary">Confirm</button>
             </form>

--- a/web/vital_records/templates/vital_records/request/order.html
+++ b/web/vital_records/templates/vital_records/request/order.html
@@ -1,5 +1,6 @@
 {% extends "vital_records/base.html" %}
 {% load i18n %}
+{% load form_helpers %}
 {% block inner-content %}
     <div class="row">
         <div class="col-md-3">
@@ -19,7 +20,7 @@
                     <h3>How many replacements do you need?</h3>
                     <div class="row">
                         <div class="col-md-3">
-                            {{ form.number_of_records.label_tag }}
+                            {{ form.number_of_records|label_with_required }}
                             {{ form.number_of_records }}
                             {{ form.number_of_records.errors }}
                         </div>
@@ -33,22 +34,22 @@
                     {% include "vital_records/_two_column_form.html" with form=form fields=name_fields %}
                     <div class="row">
                         <div class="form-group col-md-12">
-                            {{ form.address.label_tag }}
+                            {{ form.address|label_with_required }}
                             {{ form.address }}
                             {{ form.address.errors }}
                         </div>
                         <div class="form-group col-md-5">
-                            {{ form.city.label_tag }}
+                            {{ form.city|label_with_required }}
                             {{ form.city }}
                             {{ form.city.errors }}
                         </div>
                         <div class="form-group col-md-4">
-                            {{ form.state.label_tag }}
+                            {{ form.state|label_with_required }}
                             {{ form.state }}
                             {{ form.state.errors }}
                         </div>
                         <div class="form-group col-md-3">
-                            {{ form.zip_code.label_tag }}
+                            {{ form.zip_code|label_with_required }}
                             {{ form.zip_code }}
                             {{ form.zip_code.errors }}
                         </div>
@@ -63,14 +64,14 @@
                     <h3>Contact information</h3>
                     <div class="row">
                         <div class="form-group col-md-5">
-                            {{ form.email_address.label_tag }}
+                            {{ form.email_address|label_with_required }}
                             {{ form.email_address }}
                             {{ form.email_address.errors }}
                         </div>
                     </div>
                     <div class="row">
                         <div class="form-group col-md-5">
-                            {{ form.phone_number.label_tag }}
+                            {{ form.phone_number|label_with_required }}
                             {{ form.phone_number }}
                             {{ form.phone_number.errors }}
                         </div>

--- a/web/vital_records/templates/vital_records/request/statement.html
+++ b/web/vital_records/templates/vital_records/request/statement.html
@@ -1,5 +1,6 @@
 {% extends "vital_records/base.html" %}
 {% load i18n %}
+{% load form_helpers %}
 {% block inner-content %}
     <h2 class="m-t-80">Confirm your eligibility for an authorized copy</h2>
     <div class="row">
@@ -14,7 +15,7 @@
             <form method="post">
                 {% csrf_token %}
                 <div class="form-group w-50">
-                    {{ form.relationship.label_tag }}
+                    {{ form.relationship|label_with_required }}
                     {{ form.relationship }}
                 </div>
                 <p class="fw-semibold">Legal attestation</p>
@@ -23,7 +24,7 @@
                         <p class="form-help">
                             By typing your full name below, you confirm under penalty of perjury under California law that you’re eligible to request this record.
                         </p>
-                        {{ form.legal_attestation.label_tag }}
+                        {{ form.legal_attestation|label_with_required }}
                         {{ form.legal_attestation }}
                     </div>
                     {% if form.legal_attestation.errors %}<div class="error">{{ form.legal_attestation.errors }}</div>{% endif %}

--- a/web/vital_records/templatetags/form_helpers.py
+++ b/web/vital_records/templatetags/form_helpers.py
@@ -1,0 +1,13 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def label_with_required(field):
+    label = field.label or ""
+    required = ""
+    if field.field.required:
+        required = '<abbr title="required" class="text-danger">*</abbr>'
+    return mark_safe(f'<label for="{field.id_for_label}">{label} {required}</label>')


### PR DESCRIPTION
closes #106 

## What this PR does
- Creates a new `label_with_required` form helper tag
- Update all the form fields to use this `label_with_required` tag. The tag helper will determine if the field is required or not, and if it is, it will add HTML for the required title/asterisks. 

## Guidance
- https://designsystem.digital.gov/templates/form-templates/#identifying-required-fields-2
- https://www.w3.org/WAI/WCAG22/Techniques/html/H90

## Example
<img width="914" alt="image" src="https://github.com/user-attachments/assets/bb623099-4cf7-44b5-8f21-00cda89e5469" />
