### PR TITLE
Form styling

### DIFF
--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -158,6 +158,16 @@ header {
     padding: 0;
   }
 
+  small,
+  .small {
+    font-size: 14px;
+  }
+
+  small.accent {
+    color: #046b99;
+    font-weight: 700;
+  }
+
   abbr[title="required"] {
     cursor: none;
     text-decoration: none;

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -132,6 +132,10 @@ header {
   min-height: calc(100vh - 190px); /* Temporary fix for footer issue */
 }
 
+.m-b-40 {
+  margin-bottom: 40px;
+}
+
 #vital-records {
   h1 {
     font-size: 47px;
@@ -170,11 +174,41 @@ header {
 
   small.form-help {
     color: var(--gray-600, #72717c);
+    display: block;
     font-weight: 400;
+    margin-top: 4px;
+  }
+
+  .form-control {
+    border-radius: 0;
+    font-size: 18px;
+    padding: 9.5px 16px;
+  }
+
+  label {
+    margin-bottom: 12px;
+  }
+
+  .label {
+    font-size: 18px;
   }
 
   abbr[title="required"] {
     cursor: none;
     text-decoration: none;
+  }
+
+  form select {
+    font-size: 18px;
+    border-radius: 0;
+    padding: 9.5px 2.25rem 9.5px 0.75rem;
+    border-color: var(--gray-200, #d4d4d7);
+  }
+
+  form .btn[type="submit"] {
+    margin-top: 40px;
+    margin-bottom: 80px;
+    font-size: 18px;
+    padding: 8px 16px;
   }
 }

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -132,11 +132,32 @@ header {
   min-height: calc(100vh - 190px); /* Temporary fix for footer issue */
 }
 
-li[data-status="current"]:before {
-  background: gold; /* Temporary style for form debugging */
-}
-
 #vital-records {
+  h1 {
+    font-size: 47px;
+    padding-top: 20px;
+    padding-bottom: 40px;
+    margin: 0;
+  }
+
+  h2 {
+    font-size: 37px;
+    margin: 8px 0;
+  }
+
+  h3 {
+    font-size: 23px;
+  }
+
+  .main-primary {
+    margin-top: 80px;
+  }
+
+  .main-header ol {
+    margin: 0;
+    padding: 0;
+  }
+
   abbr[title="required"] {
     cursor: none;
     text-decoration: none;

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -168,6 +168,11 @@ header {
     font-weight: 700;
   }
 
+  small.form-help {
+    color: var(--gray-600, #72717c);
+    font-weight: 400;
+  }
+
   abbr[title="required"] {
     cursor: none;
     text-decoration: none;

--- a/web/vital_records/templates/vital_records/base.html
+++ b/web/vital_records/templates/vital_records/base.html
@@ -12,7 +12,7 @@
             <li>
               {% comment %} This is a placeholder link for now {% endcomment %}
               <a href="{% url 'vital_records:request_eligibility' %}"
-                 class="no-underline underline-hover">< Go back to vital records home</a>
+                 class="small no-underline underline-hover">< Go back to vital records home</a>
             </li>
           </ol>
         </nav>

--- a/web/vital_records/templates/vital_records/request/county.html
+++ b/web/vital_records/templates/vital_records/request/county.html
@@ -9,7 +9,7 @@
             {% endwith %}
         </div>
         <div class="col-md-9">
-            <small>Step 2 of 6</small>
+            <small class="accent">Step 2 of 6</small>
             <h2>What is the county of birth?</h2>
             <p class="mb-3">
                 We only have records for people born in California. If you were born in a different state, contact the county clerk in the place you were born to request a new birth record.

--- a/web/vital_records/templates/vital_records/request/county.html
+++ b/web/vital_records/templates/vital_records/request/county.html
@@ -21,7 +21,7 @@
                     {{ form.county_of_birth }}
                     {{ form.county_of_birth.errors }}
                 </div>
-                <button type="submit" class="btn btn-primary">Confirm</button>
+                <button type="submit" class="btn btn-primary">Continue</button>
             </form>
         </div>
     </div>

--- a/web/vital_records/templates/vital_records/request/dob.html
+++ b/web/vital_records/templates/vital_records/request/dob.html
@@ -11,11 +11,11 @@
         <div class="col-md-9">
             <small class="accent">Step 3 of 6</small>
             <form method="post">
-                <fieldset role="group" aria-describedby="dob-hint">
+                <fieldset class="m-y-40" role="group" aria-describedby="dob-hint">
                     <legend>
                         <h2>What is the date of birth?</h2>
                     </legend>
-                    <p id="dob-hint">If you’re not sure, enter your approximate date of birth.</p>
+                    <p id="dob-hint" class="m-b-40">If you’re not sure, enter your approximate date of birth.</p>
                     {% csrf_token %}
                     <div class="row gap-md-3">
                         <div class="col-3 col-md-2">

--- a/web/vital_records/templates/vital_records/request/dob.html
+++ b/web/vital_records/templates/vital_records/request/dob.html
@@ -17,25 +17,25 @@
                     </legend>
                     <p id="dob-hint">If you’re not sure, enter your approximate date of birth.</p>
                     {% csrf_token %}
-                    <div class="row gap-3">
-                        <div class="col-md-2">
+                    <div class="row gap-md-3">
+                        <div class="col-3 col-md-2">
                             {{ form.birth_month|label_with_required }}
                             {{ form.birth_month }}
-                            {{ form.birth_month.help_text }}
+                            <small class="form-help">{{ form.birth_month.help_text }}</small>
                         </div>
-                        <div class="col-md-2">
+                        <div class="col-3 col-md-2">
                             {{ form.birth_day|label_with_required }}
                             {{ form.birth_day }}
-                            {{ form.birth_day.help_text }}
+                            <small class="form-help">{{ form.birth_day.help_text }}</small>
                         </div>
-                        <div class="col-md-3">
+                        <div class="col-4 col-md-3">
                             {{ form.birth_year|label_with_required }}
                             {{ form.birth_year }}
-                            {{ form.birth_year.help_text }}
+                            <small class="form-help">{{ form.birth_year.help_text }}</small>
                         </div>
                     </div>
                 </fieldset>
-                <button type="submit" class="btn btn-primary">Confirm</button>
+                <button type="submit" class="btn btn-primary">Continue</button>
             </form>
         </div>
     </div>

--- a/web/vital_records/templates/vital_records/request/dob.html
+++ b/web/vital_records/templates/vital_records/request/dob.html
@@ -9,7 +9,7 @@
             {% endwith %}
         </div>
         <div class="col-md-9">
-            <small>Step 3 of 6</small>
+            <small class="accent">Step 3 of 6</small>
             <form method="post">
                 <fieldset role="group" aria-describedby="dob-hint">
                     <legend>

--- a/web/vital_records/templates/vital_records/request/eligibility.html
+++ b/web/vital_records/templates/vital_records/request/eligibility.html
@@ -5,7 +5,7 @@
     <h2 class="m-t-80">You’re eligible for free replacement records</h2>
     <div class="row">
         <div class="col-lg-10">
-            <p>
+            <p class="m-b">
                 We’re offering free replacement records for those impacted by recent wildfires. Your information helps us process your request and deliver the benefit.
             </p>
         </div>

--- a/web/vital_records/templates/vital_records/request/eligibility.html
+++ b/web/vital_records/templates/vital_records/request/eligibility.html
@@ -11,7 +11,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-lg-6">
+        <div class="col-lg-5">
             <form method="post">
                 <div class="m-y-md p-y-sm">
                     {% csrf_token %}

--- a/web/vital_records/templates/vital_records/request/name.html
+++ b/web/vital_records/templates/vital_records/request/name.html
@@ -8,7 +8,7 @@
             {% endwith %}
         </div>
         <div class="col-md-9">
-            <small>Step 1 of 6</small>
+            <small class="accent">Step 1 of 6</small>
             <form method="post" class="form">
                 <fieldset role="group" aria-describedby="name-hint">
                     <legend>

--- a/web/vital_records/templates/vital_records/request/order.html
+++ b/web/vital_records/templates/vital_records/request/order.html
@@ -9,7 +9,7 @@
             {% endwith %}
         </div>
         <div class="col-md-9">
-            <small>Step 5 of 6</small>
+            <small class="accent">Step 5 of 6</small>
             <form method="post" class="form">
                 <fieldset role="group" aria-describedby="orders-hint">
                     <legend>

--- a/web/vital_records/templates/vital_records/request/parents.html
+++ b/web/vital_records/templates/vital_records/request/parents.html
@@ -8,7 +8,7 @@
             {% endwith %}
         </div>
         <div class="col-md-9">
-            <small>Step 4 of 6</small>
+            <small class="accent">Step 4 of 6</small>
             <form method="post" class="form">
                 <fieldset role="group" aria-describedby="parents-hint">
                     <legend>

--- a/web/vital_records/templates/vital_records/request/statement.html
+++ b/web/vital_records/templates/vital_records/request/statement.html
@@ -14,7 +14,7 @@
         <div class="col-lg-10">
             <form method="post">
                 {% csrf_token %}
-                <div class="form-group w-50 p-b">
+                <div class="form-group width-60pct p-b">
                     {{ form.relationship|label_with_required }}
                     {{ form.relationship }}
                 </div>

--- a/web/vital_records/templates/vital_records/request/statement.html
+++ b/web/vital_records/templates/vital_records/request/statement.html
@@ -5,7 +5,7 @@
     <h2 class="m-t-80">Confirm your eligibility for an authorized copy</h2>
     <div class="row">
         <div class="col-lg-10">
-            <p>
+            <p class="m-t p-b m-b-sm">
                 To get an authorized copy, you must be the person named on the record or someone legally allowed to request it — like a parent, guardian, or close relative.
             </p>
         </div>
@@ -14,11 +14,11 @@
         <div class="col-lg-10">
             <form method="post">
                 {% csrf_token %}
-                <div class="form-group w-50">
+                <div class="form-group w-50 p-b">
                     {{ form.relationship|label_with_required }}
                     {{ form.relationship }}
                 </div>
-                <p class="fw-semibold">Legal attestation</p>
+                <p class="label fw-semibold">Legal attestation</p>
                 <div class="form-group border b-1 rounded bg-gray-light p-a-md">
                     <div class="custom-wrapper">
                         <p class="form-help">


### PR DESCRIPTION
#43, requires the required label PR be merged first

## What this PR does
- Style the header section
- Style the form fields, select fields, labels
- Style the typography
- Style form spacing
- Fixes some spacing so the form looks good in mobile
- Tried to use as much Bootstrap and CA State Web Template when possible. Wrote custom CSS scoped under #vital-records for the rest.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e12dd60b-594c-462a-b876-4b2391ac1142" />
<img width="943" alt="image" src="https://github.com/user-attachments/assets/b689922b-8058-48ef-8ccc-cf8b65774d3a" />
<img width="986" alt="image" src="https://github.com/user-attachments/assets/3dea67f9-c28d-431e-a4d1-02969d3f02d6" />
<img width="772" alt="image" src="https://github.com/user-attachments/assets/6c48991f-e5e9-4667-9768-ea136b9e537a" />
