### PR TITLE
Chore: pin verison of `django-cdt-identity`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12"
 maintainers = [{ name = "Compiler LLC", email = "dev@compiler.la" }]
 dependencies = [
     "Django==5.1.8",
-    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@main",
+    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@2025.04.1",
     "django-fsm-2==4.0.0",
     "gunicorn==23.0.0",
     "psycopg[binary,pool]==3.2.6",


### PR DESCRIPTION
Closes #40 