### PR TITLE
Fix: Add correct demo link

### DIFF
--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -196,6 +196,10 @@ header {
     padding: 0;
   }
 
+  .main-header .external-link-icon {
+    display: none;
+  }
+
   small,
   .small {
     font-size: 14px;

--- a/web/vital_records/templates/vital_records/base.html
+++ b/web/vital_records/templates/vital_records/base.html
@@ -11,7 +11,7 @@
           <ol>
             <li>
               {% comment %} This is a placeholder link for now {% endcomment %}
-              <a href="{% url 'vital_records:request_eligibility' %}"
+              <a href="https://www.test-cagov.cdt.ca.gov/lafires/vital-records/"
                  class="small no-underline underline-hover">< Go back to vital records home</a>
             </li>
           </ol>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/82ab7c69-1a9a-422d-8ab4-343480e624bc)

Go to vital records home now goes to: https://www.test-cagov.cdt.ca.gov/lafires/vital-records/

Added CSS to ensure the external link icon doesn't show up.