### PR TITLE
Refactor: convert worker to long-running container app

### DIFF
--- a/bin/worker.sh
+++ b/bin/worker.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eux
 
-# run DjangoQ cluster worker once
-# this script is intended to be run inside a scheduled job
+# run DjangoQ cluster worker
 
-python manage.py qcluster --run-once
+python manage.py qcluster

--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -82,7 +82,7 @@ resource "azurerm_key_vault" "main" {
   }
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = azurerm_container_app_job.worker.identity.0.principal_id
+    object_id = azurerm_container_app.worker.identity.0.principal_id
 
     secret_permissions = ["Get"]
   }

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -1,23 +1,14 @@
-resource "azurerm_container_app_job" "worker" {
+resource "azurerm_container_app" "worker" {
   name                         = lower("aca-cdt-pub-vip-ddrc-${local.env_letter}-worker")
   container_app_environment_id = azurerm_container_app_environment.main.id
-  location                     = data.azurerm_resource_group.main.location
   resource_group_name          = data.azurerm_resource_group.main.name
-  replica_timeout_in_seconds   = 45
+  revision_mode                = "Single"
+  max_inactive_revisions       = 10
 
   identity {
     identity_ids = []
     type         = "SystemAssigned"
   }
-
-  schedule_trigger_config {
-    # every minute
-    cron_expression = "*/1 * * * *"
-    # The number of replicas to run per execution. For most jobs, set the value to 1.
-    # https://learn.microsoft.com/en-us/azure/container-apps/jobs?tabs=azure-cli#job-settings
-    parallelism = 1
-  }
-
 
   secret {
     name                = "django-db-name"


### PR DESCRIPTION
Running the worker once per minute is very slow, allowing only a max of 30 requests processed per hour (since there are 2 tasks per request).

Instead keep the worker running continuously to process tasks as they hit the queue.