### PR TITLE
Feat: track and validate request ID in session

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,7 +1,8 @@
+from uuid import uuid4
+
 from django.contrib.sessions.middleware import SessionMiddleware
 
 import pytest
-
 from pytest_socket import disable_socket
 
 
@@ -25,3 +26,8 @@ def app_request(rf):
     app_request.session.save()
 
     return app_request
+
+
+@pytest.fixture
+def request_id():
+    return uuid4()

--- a/tests/pytest/vital_records/test_mixins.py
+++ b/tests/pytest/vital_records/test_mixins.py
@@ -1,0 +1,35 @@
+from django.views import View
+
+import pytest
+
+from web.vital_records.mixins import ValidateRequestIdMixin
+from web.vital_records.session import Session
+
+
+@pytest.mark.django_db
+class TestValidateRequestIdMixin:
+    class SampleView(ValidateRequestIdMixin, View):
+        def get(self, request, *args, **kwargs):
+            return "Success"
+
+    @pytest.fixture
+    def view(self, app_request):
+        v = self.SampleView()
+        v.setup(app_request)
+        return v
+
+    @pytest.fixture(autouse=True)
+    def session(self, app_request, request_id):
+        return Session(app_request, request_id)
+
+    def test_dispatch_without_valid_request_id(self, view, app_request):
+        response = view.dispatch(app_request)
+
+        assert response.status_code == 403
+
+    def test_dispatch_with_valid_request_id(self, view, app_request, request_id):
+        view.kwargs = {"pk": request_id}
+
+        response = view.dispatch(app_request)
+
+        assert response == "Success"

--- a/tests/pytest/vital_records/test_session.py
+++ b/tests/pytest/vital_records/test_session.py
@@ -1,0 +1,25 @@
+import pytest
+
+from web.vital_records.session import Session
+
+
+@pytest.mark.django_db
+class TestSession:
+    def test_init(self, app_request, request_id):
+        session = Session(app_request, request_id=request_id)
+        assert session.request_id == request_id
+
+        session = Session(app_request, reset=True)
+        assert session.request_id is None
+
+        session = Session(app_request, request_id=request_id, reset=True)
+        assert session.request_id is None
+
+    def test_request_id(self, app_request, request_id):
+        session = Session(app_request)
+        assert session.request_id is None
+        assert session._keys_request_id not in session.session
+
+        session.request_id = request_id
+        assert session.request_id == request_id
+        assert session._keys_request_id in session.session

--- a/tests/pytest/vital_records/test_session.py
+++ b/tests/pytest/vital_records/test_session.py
@@ -1,5 +1,7 @@
 import pytest
 
+from cdt_identity.claims import ClaimsResult
+
 from web.vital_records.session import Session
 
 
@@ -23,3 +25,10 @@ class TestSession:
         session.request_id = request_id
         assert session.request_id == request_id
         assert session._keys_request_id in session.session
+
+    def test_verified_email(self, app_request):
+        session = Session(app_request)
+        assert session.verified_email == ""
+
+        session.claims_result = ClaimsResult(verified={"email_verified": True, "email": "email@example.com"})
+        assert session.verified_email == "email@example.com"

--- a/web/vital_records/mixins.py
+++ b/web/vital_records/mixins.py
@@ -1,0 +1,14 @@
+from django.http import HttpResponseForbidden
+
+from web.vital_records.session import Session
+
+
+class ValidateRequestIdMixin:
+    def dispatch(self, request, *args, **kwargs):
+        session = Session(request)
+        request_id = self.kwargs.get("pk")
+
+        if session.request_id == request_id:
+            return super().dispatch(request, *args, **kwargs)
+        else:
+            return HttpResponseForbidden()

--- a/web/vital_records/session.py
+++ b/web/vital_records/session.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 from web.core.models import UserFlow
 from web.core.session import Session as CoreSession
 
@@ -7,8 +8,24 @@ def _userflow() -> UserFlow | None:
 
 
 class Session(CoreSession):
-    def __init__(self, request, reset=False):
+    _keys_request_id = "vitalrecords-requestid"
+
+    def __init__(self, request, request_id=None, reset=False):
         super().__init__(request=request, reset=reset, userflow=_userflow())
+
+        if request_id:
+            self.request_id = request_id
+        if reset:
+            self.request_id = None
+
+    @property
+    def request_id(self):
+        value = self.session.get(self._keys_request_id)
+        return UUID(value) if value else None
+
+    @request_id.setter
+    def request_id(self, value):
+        self.session[self._keys_request_id] = str(value) if value else None
 
     @property
     def verified_email(self):

--- a/web/vital_records/views.py
+++ b/web/vital_records/views.py
@@ -54,6 +54,9 @@ class StartView(EligibilityMixin, CreateView):
         next_route = self.object.complete_start()
         self.object.save()
 
+        # store generated request id in session for verification in later steps
+        Session(self.request, request_id=self.object.pk)
+
         return redirect(next_route, pk=self.object.pk)
 
 

--- a/web/vital_records/views.py
+++ b/web/vital_records/views.py
@@ -16,6 +16,7 @@ from web.vital_records.forms import (
     OrderInfoForm,
     SubmitForm,
 )
+from web.vital_records.mixins import ValidateRequestIdMixin
 from web.vital_records.models import VitalRecordsRequest
 from web.vital_records.session import Session
 
@@ -60,7 +61,7 @@ class StartView(EligibilityMixin, CreateView):
         return redirect(next_route, pk=self.object.pk)
 
 
-class StatementView(EligibilityMixin, UpdateView):
+class StatementView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = StatementForm
     template_name = "vital_records/request/statement.html"
@@ -75,7 +76,7 @@ class StatementView(EligibilityMixin, UpdateView):
         return super().form_valid(form)
 
 
-class NameView(EligibilityMixin, UpdateView):
+class NameView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = NameForm
     template_name = "vital_records/request/name.html"
@@ -101,7 +102,7 @@ class NameView(EligibilityMixin, UpdateView):
         return context
 
 
-class CountyView(EligibilityMixin, UpdateView):
+class CountyView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = CountyForm
     template_name = "vital_records/request/county.html"
@@ -116,7 +117,7 @@ class CountyView(EligibilityMixin, UpdateView):
         return super().form_valid(form)
 
 
-class DateOfBirthView(EligibilityMixin, UpdateView):
+class DateOfBirthView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = DateOfBirthForm
     template_name = "vital_records/request/dob.html"
@@ -132,7 +133,7 @@ class DateOfBirthView(EligibilityMixin, UpdateView):
         return super().form_valid(form)
 
 
-class ParentsNamesView(EligibilityMixin, UpdateView):
+class ParentsNamesView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = ParentsNamesForm
     template_name = "vital_records/request/parents.html"
@@ -161,7 +162,7 @@ class ParentsNamesView(EligibilityMixin, UpdateView):
         return context
 
 
-class OrderInfoView(EligibilityMixin, UpdateView):
+class OrderInfoView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = OrderInfoForm
     template_name = "vital_records/request/order.html"
@@ -186,7 +187,7 @@ class OrderInfoView(EligibilityMixin, UpdateView):
         return context
 
 
-class SubmitView(EligibilityMixin, UpdateView):
+class SubmitView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = SubmitForm
     template_name = "vital_records/request/confirm.html"
@@ -220,7 +221,7 @@ class SubmitView(EligibilityMixin, UpdateView):
         return context
 
 
-class SubmittedView(EligibilityMixin, DetailView):
+class SubmittedView(EligibilityMixin, ValidateRequestIdMixin, DetailView):
     model = VitalRecordsRequest
     template_name = "vital_records/submitted.html"
 


### PR DESCRIPTION
Closes #112 

* When a new `VitalRecordsRequest` is first created, save its primary key in the user's session
* On subsequent update pages for the request, validate that the session PK == the request PK