### PR TITLE
Fix: reorder user, schema, database steps in `ensure_db`

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -2,7 +2,13 @@
 set -ex
 
 # Ensure databases, users, migrations, and superuser are set up
-python manage.py ensure_db
+should_reset=${REMOTE_CONTAINERS:-false}
+if [[ -n $should_reset ]]; then
+    # running in a devcontainer, reset the DB
+    python manage.py ensure_db --reset
+else
+    python manage.py ensure_db
+fi
 
 # Load data fixtures (if any)
 valid_fixtures=$(echo "$DJANGO_DB_FIXTURES" | grep -e fixtures\.json$ || test $? = 1)

--- a/tests/pytest/core/management/commands/test_ensure_db.py
+++ b/tests/pytest/core/management/commands/test_ensure_db.py
@@ -6,6 +6,9 @@ from psycopg import sql
 
 from web.core.management.commands.ensure_db import Command
 
+# ignore UserWarnings about modifying settings.DATABASE, the whole purpose of these tests!
+pytestmark = pytest.mark.filterwarnings("ignore:Overriding setting DATABASES")
+
 DB_TEST_ALIAS = "testdb"  # Define a clear alias for these tests
 
 

--- a/tests/pytest/core/management/commands/test_ensure_db.py
+++ b/tests/pytest/core/management/commands/test_ensure_db.py
@@ -389,6 +389,7 @@ def test_ensure_users_and_db_user_exists_db_not_exists(command, mock_admin_conne
     mock_create_user = mocker.patch.object(command, "_create_database_user")
     mocker.patch.object(command, "_database_exists", return_value=False)  # DB does not exist
     mock_create_db = mocker.patch.object(command, "_create_database")
+    mock_ensure_schema_permissions = mocker.patch.object(command, "_ensure_schema_permissions")
 
     command._ensure_users_and_db(mock_admin_connection)
 
@@ -397,6 +398,7 @@ def test_ensure_users_and_db_user_exists_db_not_exists(command, mock_admin_conne
     mock_create_user.assert_not_called()
     command._database_exists.assert_called_once_with(mock_psycopg_cursor, db_name_val)
     mock_create_db.assert_called_once_with(mock_psycopg_cursor, DB_TEST_ALIAS, db_name_val, db_user_val)
+    mock_ensure_schema_permissions.assert_called_once_with(db_name_val, db_user_val)
 
 
 def test_ensure_users_and_db_skips_non_postgres(command, mock_admin_connection, mock_psycopg_cursor, settings):

--- a/tests/pytest/core/management/commands/test_ensure_db.py
+++ b/tests/pytest/core/management/commands/test_ensure_db.py
@@ -614,6 +614,16 @@ def test_ensure_superuser_creation_missing_email_env_var(command, mock_os_enviro
     mock_call_command.assert_not_called()
 
 
+def test_add_arguments(command, mocker):
+    mock_parser = mocker.Mock()
+
+    command.add_arguments(mock_parser)
+
+    mock_parser.add_argument.assert_called_once_with(
+        "--reset", action="store_true", help="Completely reset the database(s) (DESTRUCTIVE)."
+    )
+
+
 def test_handle_success_path(command, mocker):
     mock_conn_obj = mocker.MagicMock(spec=psycopg.Connection, closed=False)
 

--- a/web/core/management/commands/ensure_db.py
+++ b/web/core/management/commands/ensure_db.py
@@ -155,15 +155,14 @@ class Command(BaseCommand):
 
                 # Ensure DB User Exists
                 if not self._user_exists(cursor, db_user):
-                    admin_user = admin_conn.info.user
-                    self._create_database_user(cursor, admin_user, db_alias, db_user, db_password)
-                    self._ensure_schema_permissions(db_name, db_user)
+                    self._create_database_user(cursor, admin_conn.info.user, db_alias, db_user, db_password)
                 else:
                     self.stdout.write(f"User found: {db_user}")
 
                 # Ensure Database Exists
                 if not self._database_exists(cursor, db_name):
                     self._create_database(cursor, db_alias, db_name, db_user)  # db_user is the owner
+                    self._ensure_schema_permissions(db_name, db_user)
                 else:
                     self.stdout.write(f"Database found: {db_name}")
         finally:

--- a/web/core/management/commands/ensure_db.py
+++ b/web/core/management/commands/ensure_db.py
@@ -254,8 +254,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # database and user setup (requires admin connection)
         admin_conn = None
+        reset = options.get("reset", False)
         try:
             admin_conn = self._admin_connection()
+            if reset:
+                self._reset(admin_conn)
             self._ensure_users_and_db(admin_conn)
         except Exception as e:
             self.stderr.write(self.style.ERROR(str(e)))

--- a/web/core/management/commands/ensure_db.py
+++ b/web/core/management/commands/ensure_db.py
@@ -123,6 +123,7 @@ class Command(BaseCommand):
         Grants USAGE and CREATE permissions on the public schema of a newly created database to the specified user.
         Connects to the target database using admin credentials. Failure is considered critical as it's for a new database.
         """
+        self.stdout.write(f"Ensuring schema permissions for user: {db_user_to_grant} in database: {db_name}")
         admin_conn = None
         try:
             admin_conn = self._admin_connection(db_name)
@@ -131,10 +132,11 @@ class Command(BaseCommand):
                     user=sql.Identifier(db_user_to_grant)
                 )
                 cursor.execute(grant_query)
+                self.stdout.write("Schema permissions confirmed")
         except psycopg.Error as e:
             self.stderr.write(
                 self.style.ERROR(
-                    f"Failed to grant schema permissions in database: {db_name} for user: {db_user_to_grant}: {e}"
+                    f"Failed to grant schema permissions for user: {db_user_to_grant} in database: {db_name} : {e}"
                 )
             )
             raise CommandError(f"Failed to set schema permissions for newly created database: {db_name}.") from e

--- a/web/core/management/commands/ensure_db.py
+++ b/web/core/management/commands/ensure_db.py
@@ -222,6 +222,9 @@ class Command(BaseCommand):
         else:
             self.stdout.write("DJANGO_SUPERUSER_USERNAME environment variable not set. Skipping superuser creation.")
 
+    def add_arguments(self, parser):
+        parser.add_argument("--reset", action="store_true", help="Completely reset the database(s) (DESTRUCTIVE).")
+
     def handle(self, *args, **options):
         # database and user setup (requires admin connection)
         admin_conn = None


### PR DESCRIPTION
Previously, we ensured schema permissions _after the user was created_ but _before the database was created_. If the database didn't exist, there is no schema target for the user grants!

This PR fixes the order of operations, so:

1. User is created if needed
2. Database is created if needed
3. If database was created, ensure schema permissions

This PR also adds a flag to the `ensure_db` command: `--reset` to completely reset the database(s); e.g. dropping user and database before creation. This is mostly useful in a local development environment, e.g. we want to startup the devcontainer with a fresh DB.

Part of #150 