### PR TITLE
Fix: remove extra grant for user-->admin

### DIFF
--- a/tests/pytest/core/management/commands/test_ensure_db.py
+++ b/tests/pytest/core/management/commands/test_ensure_db.py
@@ -207,10 +207,8 @@ def test_create_database_user_success(command, mock_psycopg_cursor, mocker):
     create_sql = sql.SQL("CREATE USER {user} WITH PASSWORD {password_literal}").format(
         user=sql.Identifier(test_username), password_literal=sql.Literal(test_password)
     )
-    grant_sql = sql.SQL("GRANT {user} TO {admin}").format(user=sql.Identifier(test_username), admin=sql.Identifier(admin_user))
 
-    calls = [mocker.call(create_sql), mocker.call(grant_sql)]
-    mock_psycopg_cursor.execute.assert_has_calls(calls)
+    mock_psycopg_cursor.execute.assert_called_once_with(create_sql)
 
 
 def test_create_database_user_failure(command, mock_psycopg_cursor):

--- a/web/core/management/commands/ensure_db.py
+++ b/web/core/management/commands/ensure_db.py
@@ -106,10 +106,6 @@ class Command(BaseCommand):
                 user=sql.Identifier(username), password_literal=sql.Literal(password)
             )
             cursor.execute(query)
-            # grant the specific username role to the admin_user
-            # to allow the admin_user to create database(s) on behalf of the db_user
-            query = sql.SQL("GRANT {user} TO {admin}").format(user=sql.Identifier(username), admin=sql.Identifier(admin_user))
-            cursor.execute(query)
             self.stdout.write(self.style.SUCCESS("User created successfully"))
         except psycopg.Error as e:
             self.stderr.write(self.style.ERROR(f"Failed to create user {username} for database {db_alias}: {e}"))


### PR DESCRIPTION
Another PR related to #150.

This _may_ have been the cause of an issue that was preventing me from running the `ensure_db --reset` command in Azure. I was seeing an error message:

```console
ERROR: pq: role "django" cannot be dropped because some objects depend on it 
```

Even after completely deleting the `django` _database_ (where the `django` _user_ should have all its permission scoped). 

I had to connect to the `postgres` database as the admin user and execute:

```sql
REVOKE ALL PRIVILEGES ON SCHEMA public FROM django;
```

Which then allowed me to run:

```sql
DROP USER django;
```

While it might seem like a way for the admin to do things "on behalf of" the app user, it's generally not necessary for the operations the script performs (creating the user, creating a database owned by that user). The admin user inherently has the power to perform these setup tasks.

This specific grant is unlikely to be the direct cause of the `django` user getting permissions on `postgres.public`, but it's an unusual grant that could lead to complex inherited permissions, thus removing it. 