### PR TITLE
Fix: drop database with force

### DIFF
--- a/tests/pytest/core/management/commands/test_ensure_db.py
+++ b/tests/pytest/core/management/commands/test_ensure_db.py
@@ -89,7 +89,7 @@ def test_reset_success(command, mock_admin_connection, mock_psycopg_cursor, sett
 
     command._reset(mock_admin_connection)
 
-    drop_db = sql.SQL("DROP DATABASE IF EXISTS {db}")
+    drop_db = sql.SQL("DROP DATABASE IF EXISTS {db} WITH (FORCE)")
     drop_user = sql.SQL("DROP USER IF EXISTS {user}")
 
     calls = [

--- a/web/core/management/commands/ensure_db.py
+++ b/web/core/management/commands/ensure_db.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
                 db_name, db_user, _ = validated_config
                 try:
                     # drop the database
-                    query = sql.SQL("DROP DATABASE IF EXISTS {db}").format(db=sql.Identifier(db_name))
+                    query = sql.SQL("DROP DATABASE IF EXISTS {db} WITH (FORCE)").format(db=sql.Identifier(db_name))
                     cursor.execute(query)
                     # drop the user
                     query = sql.SQL("DROP USER IF EXISTS {user}").format(user=sql.Identifier(db_user))


### PR DESCRIPTION
Another part of #150

Postgres 13+ supports `WITH (FORCE)` that attempts to close existing connections, which would otherwise prevent the database from being dropped.