### PR TITLE
Fix: reorder reset commands

### DIFF
--- a/tests/pytest/core/management/commands/test_ensure_db.py
+++ b/tests/pytest/core/management/commands/test_ensure_db.py
@@ -95,11 +95,11 @@ def test_reset_success(command, mock_admin_connection, mock_psycopg_cursor, sett
     drop_user = sql.SQL("DROP USER IF EXISTS {user}")
 
     calls = [
-        mocker.call(revoke_role.format(role_to_revoke=sql.Identifier("u1"), grantee_admin=sql.Identifier("admin"))),
         mocker.call(drop_db.format(db=sql.Identifier("db1"))),
+        mocker.call(revoke_role.format(role_to_revoke=sql.Identifier("u1"), grantee_admin=sql.Identifier("admin"))),
         mocker.call(drop_user.format(user=sql.Identifier("u1"))),
-        mocker.call(revoke_role.format(role_to_revoke=sql.Identifier("u2"), grantee_admin=sql.Identifier("admin"))),
         mocker.call(drop_db.format(db=sql.Identifier("db2"))),
+        mocker.call(revoke_role.format(role_to_revoke=sql.Identifier("u2"), grantee_admin=sql.Identifier("admin"))),
         mocker.call(drop_user.format(user=sql.Identifier("u2"))),
     ]
     mock_psycopg_cursor.execute.assert_has_calls(calls)


### PR DESCRIPTION
Another part of #150.

The correct order of operations should be:

1. `DROP DATABASE IF EXISTS {db} WITH (FORCE)`: At this point, the admin_user should still have the `{app_user}` role granted to it (from any previous successful `ensure_db` run). This allows `admin_user` (in Azure's model) to have the necessary privileges (implicitly, the ability to `SET ROLE` to the owner) to drop the database owned by `{app_user}`.

2. `REVOKE {app_role} FROM {admin_user}`: After the database is successfully dropped, revoke the application role from the admin user. This severs the membership link.

3. `DROP ROLE IF EXISTS {user}`: Now, this command should succeed because:
    - The primary object owned by `{user}` (the database) is gone. 
    - The membership dependency (admin user being a member of the app role) has been removed.