### PR TITLE
Feat: improve Docker caching

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,13 @@ RUN apt install webp -y
 
 USER $USER
 
-COPY . .
+COPY .git .git
+COPY pyproject.toml pyproject.toml
 
-# install devcontainer requirements
-RUN pip install -e .[dev,test]
+# this RUN command uses pipcache
+# setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root
+# even though we are running in the context of non-root $USER
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+     pip install -e .[dev,test]
+
+COPY . .

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,16 @@
 FROM cdt/disaster-recovery:web
 
-# install Azure CLI
-# https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 USER root
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# install webp CLI
-# https://developers.google.com/speed/webp/download
-RUN apt install webp -y
+# install apt packages using the archives and lists cache
+RUN --mount=type=cache,id=apt-archives,sharing=locked,target=/var/cache/apt/archives \
+    --mount=type=cache,id=apt-lists,sharing=locked,target=/var/lib/apt/lists \
+    # install Azure CLI
+    # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
+    curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
+    # install webp CLI
+    # https://developers.google.com/speed/webp/download
+    apt install webp -y
 
 USER $USER
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,12 @@
+.pytest_cache/
 *.egg-info
-*.db
+.coverage
+.env*
+.flake8
+.pre-commit-config.yaml
+compose.yml
+*fixtures.json
+app/
+inbox/
+terraform/
+tests/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,14 +80,23 @@ jobs:
         run: |
           echo "lower=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
 
+      - name: Cache Parameters
+        id: cache_params
+        run: |
+          CACHE_SCOPE="ca-disaster-recovery"
+          MAIN_BRANCH_REF="refs/heads/main"
+
+          echo "cache_from_args=type=gha,scope=${CACHE_SCOPE},ref=${MAIN_BRANCH_REF}" >> $GITHUB_OUTPUT
+          echo "cache_to_args=type=gha,scope=${CACHE_SCOPE},mode=max,ref=${MAIN_BRANCH_REF}" >> $GITHUB_OUTPUT
+
       - name: Build, tag, and push image to GitHub Container Registry
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           build-args: GIT-SHA=${{ github.sha }}
-          cache-from: type=gha,scope=office-of-digital-services
-          cache-to: type=gha,scope=office-of-digital-services,mode=max
+          cache-from: ${{ steps.cache_params.outputs.cache_from_args }}
+          cache-to: ${{ steps.cache_params.outputs.cache_to_args }}
           context: .
           file: appcontainer/Dockerfile
           push: true

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -101,8 +101,12 @@ ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
 EXPOSE 8000
 
 USER root
+
+# install apt packages using the archives and lists cache
+RUN --mount=type=cache,id=apt-archives,sharing=locked,target=/var/cache/apt/archives \
+    --mount=type=cache,id=apt-lists,sharing=locked,target=/var/lib/apt/lists \
     # (re)create non-root $USER and home directory (since it isn't copied from previous stage)
-RUN groupadd --gid ${USER_GID} ${USER} 2>/dev/null || true && \
+    groupadd --gid ${USER_GID} ${USER} 2>/dev/null || true && \
     useradd --uid ${USER_UID} --gid ${USER_GID} --create-home --shell /bin/bash ${USER} && \
     # pip cache dir must be created and owned by the user to work with BuildKit cache
     mkdir -p ${PIP_CACHE_DIR} && \
@@ -125,7 +129,9 @@ RUN groupadd --gid ${USER_GID} ${USER} 2>/dev/null || true && \
     chown -R $USER:$USER /$USER && \
     # install server components
     apt-get update && \
-    apt-get install -qq --no-install-recommends build-essential nginx gettext && \
+    apt-get install -y --no-install-recommends build-essential nginx gettext && \
+    # this cleanup is still important for the final image layer size
+    # remove lists from the image layer, but they remain in the BuildKit cache mount
     rm -rf /var/lib/apt/lists/*
 
 # enter source directory

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -1,22 +1,71 @@
-ARG PYTHON_VERSION=3.12
+# declare default build args for later stages
+ARG PYTHON_VERSION=3.12 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    USER=cdt \
+    USER_UID=1000 \
+    USER_GID=1000
 
 # multi-stage build
 #
 # stage 1: builds the web package from source
 #          using the git metadata for version info
 FROM python:${PYTHON_VERSION} AS build_wheel
+
+# renew top-level args in this stage
+ARG PYTHON_VERSION \
+    PYTHONDONTWRITEBYTECODE \
+    PYTHONUNBUFFERED \
+    USER \
+    USER_UID \
+    USER_GID
+
+# set env vars for the user, including HOME
+ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    HOME=/home/${USER} \
+    USER=${USER} \
+    PATH="/home/${USER}/.local/bin:$PATH" \
+    # update env for local pip installs
+    # see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
+    # since all `pip install` commands are in the context of $USER
+    # $PYTHONUSERBASE is the location used by default
+    PYTHONUSERBASE="/home/${USER}/.local" \
+    # where to store the pip cache (use the default)
+    # https://pip.pypa.io/en/stable/cli/pip/#cmdoption-cache-dir
+    PIP_CACHE_DIR="/home/${USER}/.cache/pip"
+
+# Create the user, their home directory, .cache/pip, and /build directory.
+# Set ownership before switching user. This runs as root.
+USER root
+RUN groupadd --gid ${USER_GID} ${USER} 2>/dev/null || true && \
+    useradd --uid ${USER_UID} --gid ${USER_GID} --create-home --shell /bin/bash ${USER} && \
+    # pip cache dir must be created and owned by the user to work with BuildKit cache
+    mkdir -p ${PIP_CACHE_DIR} && \
+    # own the parent directory of PIP_CACHE_DIR
+    chown -R ${USER}:${USER} /home/${USER}/.cache && \
+    mkdir /build && \
+    chown ${USER}:${USER} /build
+
+# switch to non-root user
+USER $USER
 WORKDIR /build
+# upgrade pip and install the 'build' package as user
+# setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root
+# even though we are running in the context of non-root $USER
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+    python -m pip install --user --upgrade pip && \
+    pip install --user build
 
-# upgrade pip
-RUN python -m pip install --upgrade pip && \
-    pip install build
-
-# copy source files
+# copy all source files; changes here will invalidate subsequent Docker layers
 COPY . .
 RUN git config --global --add safe.directory /build
 
-# build package
-RUN python -m build
+# build the wheel, using the pip cache for any build-time dependencies
+# setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root
+# even though we are running in the context of non-root $USER
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+    python -m build
 
 # multi-stage build
 #
@@ -24,14 +73,41 @@ RUN python -m build
 #          using the pre-built package, and copying only needed source
 FROM python:${PYTHON_VERSION} AS app_container
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    USER=cdt
+# renew top-level args in this stage
+ARG PYTHON_VERSION \
+    PYTHONDONTWRITEBYTECODE \
+    PYTHONUNBUFFERED \
+    USER \
+    USER_UID \
+    USER_GID
+
+# set env vars from args so they persist into running containers
+ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    HOME=/home/${USER} \
+    USER=${USER} \
+    USER_UID=${USER_UID} \
+    USER_GID=${USER_GID} \
+    PATH="/home/${USER}/.local/bin:$PATH" \
+    # update env for local pip installs
+    # see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
+    # since all `pip install` commands are in the context of $USER
+    # $PYTHONUSERBASE is the location used by default
+    PYTHONUSERBASE="/home/${USER}/.local" \
+    # where to store the pip cache (use the default)
+    # https://pip.pypa.io/en/stable/cli/pip/#cmdoption-cache-dir
+    PIP_CACHE_DIR="/home/${USER}/.cache/pip"
 
 EXPOSE 8000
 
-    # create non-root $USER and home directory
-RUN useradd --create-home --shell /bin/bash $USER && \
+USER root
+    # (re)create non-root $USER and home directory (since it isn't copied from previous stage)
+RUN groupadd --gid ${USER_GID} ${USER} 2>/dev/null || true && \
+    useradd --uid ${USER_UID} --gid ${USER_GID} --create-home --shell /bin/bash ${USER} && \
+    # pip cache dir must be created and owned by the user to work with BuildKit cache
+    mkdir -p ${PIP_CACHE_DIR} && \
+    # own the PIP_CACHE_DIR parent .cache dir
+    chown -R ${USER}:${USER} /home/${USER}/.cache && \
     # setup $USER permissions for nginx
     mkdir -p /var/cache/nginx && \
     chown -R $USER:$USER /var/cache/nginx && \
@@ -50,41 +126,38 @@ RUN useradd --create-home --shell /bin/bash $USER && \
     # install server components
     apt-get update && \
     apt-get install -qq --no-install-recommends build-essential nginx gettext && \
-    python -m pip install --upgrade pip
+    rm -rf /var/lib/apt/lists/*
 
 # enter source directory
 WORKDIR /$USER
 
+# copy mostly static files
 COPY LICENSE app/LICENSE
+COPY manage.py app/manage.py
+COPY appcontainer/gunicorn.conf.py run/gunicorn.conf.py
+# overwrite default nginx.conf
+COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
+# copy certs for PostgreSQL verify-full
+COPY appcontainer/certs/azure_postgres_ca_bundle.pem app/certs/azure_postgres_ca_bundle.pem
+# copy the wheel built in the previous stage
+COPY --from=build_wheel /build/dist /build/dist
 
 # switch to non-root $USER
 USER $USER
-
-# update env for local pip installs
-# see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
-# since all `pip install` commands are in the context of $USER
-# $PYTHONUSERBASE is the location used by default
-ENV PATH="$PATH:/$USER/.local/bin" \
-    PYTHONUSERBASE="/$USER/.local"
-
-# copy gunicorn config file
-COPY appcontainer/gunicorn.conf.py run/gunicorn.conf.py
-ENV GUNICORN_CONF="/$USER/run/gunicorn.conf.py"
-
-# overwrite default nginx.conf
-COPY appcontainer/nginx.conf /etc/nginx/nginx.conf
-
 WORKDIR /$USER/app
 
-# copy runtime files
-COPY --from=build_wheel /build/dist /build/dist
-COPY manage.py manage.py
-COPY bin bin
-COPY appcontainer/certs/azure_postgres_ca_bundle.pem certs/azure_postgres_ca_bundle.pem
-COPY web web
+# env var needed for gunicorn
+ENV GUNICORN_CONF="/$USER/run/gunicorn.conf.py"
 
-# install source as a package
-RUN pip install $(find /build/dist -name cdt_disaster_recovery*.whl)
+# copy runtime files
+COPY bin bin
+
+# install the locally built wheel and its dependencies using the pip cache
+# setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root
+# even though we are running in the context of non-root $USER
+RUN --mount=type=cache,id=pipcache,target=${PIP_CACHE_DIR},uid=${USER_UID},gid=${USER_GID} \
+    python -m pip install --user --upgrade pip && \
+    pip install --user $(find /build/dist -name "cdt_disaster_recovery*.whl")
 
 # configure container executable
 ENTRYPOINT ["/bin/bash"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cdt-disaster-recovery"
 dynamic = ["version"]
 description = "State of California Digital Disaster Recovery Center."
 readme = "README.md"
-license = { file = "LICENSE" }
+license-files = ["LICENSE"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.12"
 maintainers = [{ name = "Compiler LLC", email = "dev@compiler.la" }]
@@ -15,6 +15,7 @@ dependencies = [
     "django-google-sso==8.0.0",
     "django-q2==1.8.0",
     "gunicorn==23.0.0",
+    "pandas==2.2.3",
     "psycopg[binary,pool]==3.2.9",
     "pypdf==5.5.0",
     "requests==2.32.3",
@@ -51,6 +52,11 @@ source = ["web"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.pytest.settings"
+
+# This section ensures setuptools is fully aware that non-code files within
+# these packages should be bundled
+[tool.setuptools]
+include-package-data = true
 
 [tool.setuptools.packages.find]
 include = ["web*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12"
 maintainers = [{ name = "Compiler LLC", email = "dev@compiler.la" }]
 dependencies = [
     "Django==5.2.1",
-    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@2025.04.1",
+    "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",
     "django-csp==3.8",
     "django-fsm-2==4.0.0",
     "django-google-sso==8.0.0",


### PR DESCRIPTION
* ignore unneeded files/directory in Docker context
* improve Docker layer caching be ordering some commands
* use Buildkit cache mount to cache pip installs
* use Buildkit cache mounts to cache apt installs
* in CI/CD, explicitly use the `main` branch ref cache, so all Docker builds (e.g. `main` and tags) can take advantage