### PR TITLE
Fix: make cert path absolute

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -157,13 +157,14 @@ WSGI_APPLICATION = "web.wsgi.application"
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 sslmode = os.environ.get("POSTGRES_SSLMODE", "verify-full")
-sslrootcert = os.path.join(BASE_DIR, "certs", "azure_postgres_ca_bundle.pem") if sslmode == "verify-full" else None
+# resolve to get the absolute, normalized path to the bundle
+sslrootcert = Path(BASE_DIR, "certs", "azure_postgres_ca_bundle.pem").resolve() if sslmode == "verify-full" else None
 PG_CONFIG = {
     "ENGINE": "django.db.backends.postgresql",
     "HOST": os.environ.get("POSTGRES_HOSTNAME", "postgres"),
     "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-    "OPTIONS": {"sslmode": sslmode, "sslrootcert": sslrootcert},
+    "OPTIONS": {"sslmode": sslmode, "sslrootcert": str(sslrootcert)},
 }
 DATABASES = {
     "default": PG_CONFIG


### PR DESCRIPTION
Resolving an error seen running in Azure:

```log
connection failed: connection to server at "x.x.x.x", port 5432 failed: 
root certificate file "/home/cdt/.local/lib/python3.12/site-packages/certs/azure_postgres_ca_bundle.pem" does not exist
```

The bundle path is relative and pointing to `/home/cdt/.local/lib/python3.12/site-packages/certs`

But the bundle lives in `/cdt/app/certs`