### PR TITLE
Refactor: runtime directory environment variable

### DIFF
--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -97,7 +97,9 @@ ENV PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
     # where to store the pip cache (use the default)
     # https://pip.pypa.io/en/stable/cli/pip/#cmdoption-cache-dir
     PIP_CACHE_DIR="/home/${USER}/.cache/pip" \
-    POSTGRES_SSLROOTCERT_PATH="/${USER}/app/certs/azure_postgres_ca_bundle.pem"
+    RUNTIME_DIR="/${USER}/app"
+
+ENV POSTGRES_SSLROOTCERT_PATH="${RUNTIME_DIR}/certs/azure_postgres_ca_bundle.pem"
 
 EXPOSE 8000
 
@@ -151,7 +153,7 @@ COPY --from=build_wheel /build/dist /build/dist
 
 # switch to non-root $USER
 USER $USER
-WORKDIR /$USER/app
+WORKDIR ${RUNTIME_DIR}
 
 # env var needed for gunicorn
 ENV GUNICORN_CONF="/$USER/run/gunicorn.conf.py"

--- a/appcontainer/Dockerfile
+++ b/appcontainer/Dockerfile
@@ -160,6 +160,7 @@ ENV GUNICORN_CONF="/$USER/run/gunicorn.conf.py"
 
 # copy runtime files
 COPY bin bin
+COPY web/static web/static
 
 # install the locally built wheel and its dependencies using the pip cache
 # setting uid,gid here is critical, as otherwise the Buildkit cache is mounted as root

--- a/web/settings.py
+++ b/web/settings.py
@@ -17,6 +17,8 @@ def _filter_empty(ls):
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+# The working directory at runtime
+RUNTIME_DIR = Path(os.environ.get("RUNTIME_DIR", BASE_DIR))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "secret")

--- a/web/settings.py
+++ b/web/settings.py
@@ -217,7 +217,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 STATIC_URL = "/static/"
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "web", "static")]
+STATICFILES_DIRS = [os.path.join(RUNTIME_DIR, "web", "static")]
 # use Manifest Static Files Storage by default
 STORAGES = {
     "default": {
@@ -229,10 +229,10 @@ STORAGES = {
         )
     },
 }
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_ROOT = os.path.join(RUNTIME_DIR, "static")
 
 # Storage for e.g. generated files, not routable from the website
-STORAGE_DIR = os.environ.get("DJANGO_STORAGE_DIR", BASE_DIR)
+STORAGE_DIR = os.environ.get("DJANGO_STORAGE_DIR", RUNTIME_DIR)
 
 # Email
 # https://docs.djangoproject.com/en/5.1/ref/settings/#email-backend


### PR DESCRIPTION
Follow up to #225 #226 #227, this was the actual problem:

In `settings.py` we set `BASE_DIR = Path(__file__).resolve().parent.parent` (the parent directory of where the file is).

However at runtime, this is the path where the library is installed (since it was built and installed as a wheel during Docker build). Moreover, the static files (CSS, images, etc.) were not being copied, dropped accidentally as part of #204

This PR fixes the situation by using a common `RUNTIME_DIR` for settings that need the actual `$PWD` inside the container, while leaving `BASE_DIR` as-is.