### PR TITLE
Fix: include manual for tagged pipeline runs

### DIFF
--- a/terraform/pipeline/workspace.py
+++ b/terraform/pipeline/workspace.py
@@ -23,9 +23,9 @@ if REASON == "PullRequest" and TARGET == "main":
 elif REASON in ["IndividualCI", "Manual"] and SOURCE == "main":
     # it's being run on the main branch, this is for the dev environment
     environment = "dev"
-elif REASON in ["IndividualCI"] and IS_TAG and re.fullmatch(r"20\d\d.\d\d.\d+-rc\d+", SOURCE):
+elif REASON in ["IndividualCI", "Manual"] and IS_TAG and re.fullmatch(r"20\d\d.\d\d.\d+-rc\d+", SOURCE):
     environment = "test"
-elif REASON in ["IndividualCI"] and IS_TAG and re.fullmatch(r"20\d\d.\d\d.\d+", SOURCE):
+elif REASON in ["IndividualCI", "Manual"] and IS_TAG and re.fullmatch(r"20\d\d.\d\d.\d+", SOURCE):
     environment = "prod"
 else:
     # default to running against dev


### PR DESCRIPTION
Since the deploy workflow is kicking off the pipeline run, the `REASON == "MANUAL"`. 

Hence the pipeline wasn't selecting the correct Terraform environment (`test`, `prod`) for tagged runs, instead
defaulting to `dev`.