### PR TITLE
Refactor: Change Date of Birth's month to a Select

### DIFF
--- a/web/vital_records/forms.py
+++ b/web/vital_records/forms.py
@@ -3,6 +3,22 @@ from django import forms
 
 from web.vital_records.models import VitalRecordsRequest
 
+MONTH_DISPLAY_CHOICES = [
+    ("", "Select"),
+    (1, "01 - January"),
+    (2, "02 - February"),
+    (3, "03 - March"),
+    (4, "04 - April"),
+    (5, "05 - May"),
+    (6, "06 - June"),
+    (7, "07 - July"),
+    (8, "08 - August"),
+    (9, "09 - September"),
+    (10, "10 - October"),
+    (11, "11 - November"),
+    (12, "12 - December"),
+]
+
 
 class EligibilityForm(forms.ModelForm):
     fire = forms.ChoiceField(
@@ -62,39 +78,27 @@ class CountyForm(forms.ModelForm):
 
 
 class DateOfBirthForm(forms.ModelForm):
-    birth_month = forms.CharField(
+    birth_month = forms.ChoiceField(
+        choices=MONTH_DISPLAY_CHOICES,
         label="Month",
-        help_text="MM",
-        widget=forms.TextInput(
-            attrs={
-                "class": "form-control",
-                "autocomplete": "bday-month",
-                "required": "",
-                "inputmode": "numeric",
-                "pattern": "[0-9]*",
-                "maxlength": "2",
-                "aria-describedby": "id_birth_month_helptext",
-            },
-        ),
+        required=True,
+        widget=forms.Select(attrs={"class": "form-select"}),
     )
     birth_day = forms.CharField(
         label="Day",
-        help_text="DD",
         widget=forms.TextInput(
             attrs={
                 "class": "form-control",
                 "autocomplete": "bday-day",
                 "required": "",
                 "inputmode": "numeric",
-                "pattern": "[0-9]*",
+                "pattern": "(3[01]|[12][0-9]|0?[1-9])",
                 "maxlength": "2",
-                "aria-describedby": "id_birth_day_helptext",
             },
         ),
     )
     birth_year = forms.CharField(
         label="Year",
-        help_text="YYYY",
         widget=forms.TextInput(
             attrs={
                 "class": "form-control",
@@ -104,7 +108,6 @@ class DateOfBirthForm(forms.ModelForm):
                 "pattern": "[0-9]*",
                 "minlength": "4",
                 "maxlength": "4",
-                "aria-describedby": "id_birth_year_helptext",
             },
         ),
     )

--- a/web/vital_records/templates/vital_records/request/dob.html
+++ b/web/vital_records/templates/vital_records/request/dob.html
@@ -18,20 +18,17 @@
                     <p id="dob-hint" class="m-b-40">If you’re not sure, enter your approximate date of birth.</p>
                     {% csrf_token %}
                     <div class="row gap-md-3">
-                        <div class="col-3 col-md-2">
+                        <div class="col-3 col-md-3">
                             {{ form.birth_month|label_with_required }}
                             {{ form.birth_month }}
-                            <small class="form-help">{{ form.birth_month.help_text }}</small>
                         </div>
                         <div class="col-3 col-md-2">
                             {{ form.birth_day|label_with_required }}
                             {{ form.birth_day }}
-                            <small class="form-help">{{ form.birth_day.help_text }}</small>
                         </div>
-                        <div class="col-4 col-md-3">
+                        <div class="col-4 col-md-2">
                             {{ form.birth_year|label_with_required }}
                             {{ form.birth_year }}
-                            <small class="form-help">{{ form.birth_year.help_text }}</small>
                         </div>
                     </div>
                 </fieldset>


### PR DESCRIPTION
closes #165 

Update date of birth's month field to follow USWDS's guidance: https://designsystem.digital.gov/patterns/create-a-user-profile/date-of-birth/#guidance-2 by changing the text field into a Select field with the month displayed as a numberal and the name. Add a `Select` placeholder blank option. Month is still required. Month is displayed as a name on the confirmation still. 

<img width="1242" alt="image" src="https://github.com/user-attachments/assets/360778e7-fcb4-4c1f-aaea-3ea29ae0baaa" />
<img width="715" alt="image" src="https://github.com/user-attachments/assets/499123f7-e0c3-4b56-bd6c-69fb426fc473" />
<img width="848" alt="image" src="https://github.com/user-attachments/assets/52291591-0670-4241-90d1-437cba7bffb7" />
