### PR TITLE
Fix: correct host forwarding

### DIFF
--- a/appcontainer/nginx.conf
+++ b/appcontainer/nginx.conf
@@ -69,7 +69,10 @@ http {
     # app path
     location @proxy_to_app {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
+      # Pass the forwarded-proto and forwarded-host headers from the App Gateway
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header X-Forwarded-Host $http_x_forwarded_host;
+      # Pass the host header received by nginx
       proxy_set_header Host $http_host;
       # we don't want nginx trying to do something clever with
       # redirects, we set the Host: header above already.

--- a/terraform/modules/app_gateway/main.tf
+++ b/terraform/modules/app_gateway/main.tf
@@ -116,9 +116,7 @@ resource "azurerm_application_gateway" "main" {
     cookie_based_affinity               = "Disabled"
     # Always override the host header.
     pick_host_name_from_backend_address = false
-    # In prod, use the custom hostname.
-    # In non-prod, use the App Gateway's default FQDN.
-    host_name                           = var.is_prod ? var.hostname : azurerm_public_ip.app_gateway.fqdn
+    host_name                           = var.backend_fqdns.web
     path                                = "/"
     port                                = 80
     probe_name                          = "${local.probe_name}-web"


### PR DESCRIPTION
Follow up to #236 

Part of #187 and #188 

* The App Gateway needs to have its `backend_settings.host_name` attribute match the container app's FQDN, so it knows where to route the traffic
* Nginx needs to forward the `X-Forwarded-Proto` and `X-Forwarded-Host` headers from the App Gateway for the [`USE_X_FORWARDED_HOST`](https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-USE_X_FORWARDED_HOST) Django setting to work correctly