### PR TITLE
Fix: email both text and HTML content

### DIFF
--- a/web/vital_records/templates/vital_records/email.txt
+++ b/web/vital_records/templates/vital_records/email.txt
@@ -1,0 +1,18 @@
+Hello,
+
+You recently completed an application for the following:
+
+Vital Record Type: Birth
+
+Number of copies: {{ number_of_copies }}
+
+Your application (attached as a PDF to this email) will be sent to CDPH for processing. CDPH typically process applications within 1-2 business days. Once processed, your records will be mailed to you, which typically takes 1-2 weeks from the date completed.
+
+You may use your email address {{ email_address }} as your reference number.
+
+If you have any questions, please contact CDPH by emailing SOEVitalRecords@cdph.ca.gov.
+
+Thank you,
+California Department of Public Health - Vital Records Issuance Branch
+
+CONFIDENTIALITY NOTICE: This communication with its contents may contain confidential and/or legally privileged information. It is solely for the use of the intended recipient(s). Unauthorized interception, review, use or disclosure is prohibited and may violate applicable laws including the Electronic Communications Privacy Act. If you are not the intended recipient, please contact the sender and destroy all copies of the communication. Your receipt of this message is not intended to waive any applicable privilege.


### PR DESCRIPTION
- copy the HTML template to a simple text-only with the same placeholders
- use that to populate an EmailMultiAlteratives instance to send both a text body and HTML body

## Reviewing

- Follow the setup instructions from #220 to setup your local to send email via Azure
- Update `VITAL_RECORDS_EMAIL_TO` to your own email
- Rebuild/reopen devcontainer
- Submit a request
- Run `Django: QCluser once` (twice) to generate the package and send the PDF
- Check your inbox, you should see the HTML email content rendered correctly

![image](https://github.com/user-attachments/assets/37b329d6-027e-454d-9a8c-ff07b1df2e58)
