### PR TITLE
Refactor: pipeline allowed IPs

### DIFF
--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -1,32 +1,12 @@
 # Imports all the submodules and wires together necessary input/outputs
 locals {
-  application_insights_name        = "AI-CDT-PUB-VIP-DDRC-${local.env_letter}-001"
-  communication_service_name       = "ACS-PUB-VIP-DDRC-${local.env_letter}-001"
-  container_app_environment_prefix = "CAE-CDT-PUB-VIP-DDRC-${local.env_letter}"
-  container_app_prefix             = lower("aca-cdt-pub-vip-ddrc-${local.env_letter}")
-  database_server_name             = lower("adb-cdt-pub-vip-ddrc-${local.env_letter}-db")
-  diagnostic_setting_prefix        = lower("MDS-CDT-PUB-VIP-DDRC-${local.env_letter}")
-  key_vault_name                   = "KV-CDT-PUB-DDRC-${local.env_letter}-001"
-  key_vault_allowed_ips = [
-    # Central United States
-    "20.37.158.0/23",
-    # West Central United States
-    "52.150.138.0/24",
-    # East United States
-    "20.42.5.0/24",
-    # East 2 United States
-    "20.41.6.0/23",
-    # North United States
-    "40.80.187.0/24",
-    # South United States
-    "40.119.10.0/24",
-    # West United States
-    "40.82.252.0/24",
-    # West 2 United States
-    "20.42.134.0/23",
-    # West 3 United States
-    "20.125.155.0/24"
-  ]
+  application_insights_name         = "AI-CDT-PUB-VIP-DDRC-${local.env_letter}-001"
+  communication_service_name        = "ACS-PUB-VIP-DDRC-${local.env_letter}-001"
+  container_app_environment_prefix  = "CAE-CDT-PUB-VIP-DDRC-${local.env_letter}"
+  container_app_prefix              = lower("aca-cdt-pub-vip-ddrc-${local.env_letter}")
+  database_server_name              = lower("adb-cdt-pub-vip-ddrc-${local.env_letter}-db")
+  diagnostic_setting_prefix         = lower("MDS-CDT-PUB-VIP-DDRC-${local.env_letter}")
+  key_vault_name                    = "KV-CDT-PUB-DDRC-${local.env_letter}-001"
   key_vault_secret_uri_prefix       = "https://${local.key_vault_name}.vault.azure.net/secrets"
   location                          = data.azurerm_resource_group.main.location
   log_analytics_workspace_name      = "CDT-OET-PUB-DDRC-${local.env_letter}-001"
@@ -102,7 +82,7 @@ module "key_vault" {
   resource_group_name = local.resource_group_name
   location            = local.location
   tenant_id           = local.tenant_id
-  allowed_ip_rules    = concat(var.KEY_VAULT_ALLOWED_IPS, local.key_vault_allowed_ips)
+  allowed_ip_rules    = var.PIPELINE_ALLOWED_IPS
   base_access_policy_object_ids = {
     engineering_group = var.ENGINEERING_GROUP_OBJECT_ID
     devsecops_group   = var.DEVSECOPS_OBJECT_ID

--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -120,7 +120,7 @@ steps:
       command: plan
       # wait for lock to be released, in case being used by another pipeline run
       # https://discuss.hashicorp.com/t/terraform-plan-wait-for-lock-to-be-released/6870/2
-      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="KEY_VAULT_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)/32\"]"
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="PIPELINE_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)/32\"]"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
@@ -138,7 +138,7 @@ steps:
       provider: azurerm
       command: apply
       # (ditto the lock comment above)
-      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="KEY_VAULT_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)/32\"]"
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="PIPELINE_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)/32\"]"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"

--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -120,7 +120,7 @@ steps:
       command: plan
       # wait for lock to be released, in case being used by another pipeline run
       # https://discuss.hashicorp.com/t/terraform-plan-wait-for-lock-to-be-released/6870/2
-      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="KEY_VAULT_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)\"]"
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="KEY_VAULT_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)/32\"]"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"
@@ -138,7 +138,7 @@ steps:
       provider: azurerm
       command: apply
       # (ditto the lock comment above)
-      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="KEY_VAULT_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)\"]"
+      commandOptions: -input=false -lock-timeout=5m -var="container_tag=$(container_tag)" -var="SLACK_NOTIFY_EMAIL=$(slack-ddrc-notify-email)" -var="KEY_VAULT_ALLOWED_IPS=[\"$(GetAgentIP.agent_ip)/32\"]"
       workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
       # service connection
       environmentServiceNameAzureRM: "${{ parameters.service_connection }}"

--- a/terraform/terraform.tfvars.sample
+++ b/terraform/terraform.tfvars.sample
@@ -3,5 +3,5 @@ DEVSECOPS_OBJECT_ID         = "object-id"
 ENGINEERING_GROUP_OBJECT_ID = "object-id"
 # These are the IPV4 ranges for the geography where the DevOps project is located (United States)
 # https://learn.microsoft.com/en-us/azure/devops/organizations/security/allow-list-ip-url?view=azure-devops&tabs=IP-V4#inbound-connections
-KEY_VAULT_ALLOWED_IPS       = []
+PIPELINE_ALLOWED_IPS       = []
 SLACK_NOTIFY_EMAIL          = "channel-email@org.slack.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,15 +16,15 @@ variable "ENGINEERING_GROUP_OBJECT_ID" {
   type        = string
 }
 
-variable "KEY_VAULT_ALLOWED_IPS" {
-  description = "List of IP addresses to grant ACL access to Key Vault."
-  type        = list(string)
-  default     = []
-}
-
 variable "SLACK_NOTIFY_EMAIL" {
   description = "Slack channel email for the DDRC engineering team"
   type        = string
+}
+
+variable "PIPELINE_ALLOWED_IPS" {
+  description = "List of IP addresses to grant ACL access for running Terraform (locally or in the cloud)."
+  type        = list(string)
+  default     = []
 }
 
 variable "container_tag" {


### PR DESCRIPTION
We don't need to hardcode the giant list of defaults, it has no effect.

There was a small correction to add the CIDR prefix `/32` to the dynamic IP address added in the pipeline, as required by Key Vault.