### PR TITLE
Chore: use normalized Key Vault name

### DIFF
--- a/terraform/modules/key_vault/monitoring.tf
+++ b/terraform/modules/key_vault/monitoring.tf
@@ -1,7 +1,7 @@
 # Diagnostic settings for the Key Vault
 resource "azurerm_monitor_diagnostic_setting" "key_vault" {
   name                       = "${var.diagnostic_setting_prefix}-kv"
-  target_resource_id         = azurerm_key_vault.main.id
+  target_resource_id         = local.normalized_key_vault_id
   log_analytics_workspace_id = var.log_analytics_workspace_id
 
   enabled_log {

--- a/terraform/modules/key_vault/network.tf
+++ b/terraform/modules/key_vault/network.tf
@@ -28,7 +28,7 @@ resource "azurerm_private_endpoint" "key_vault" {
   private_service_connection {
     name                           = "${var.private_service_connection_prefix}-kv"
     is_manual_connection           = false
-    private_connection_resource_id = azurerm_key_vault.main.id
+    private_connection_resource_id = local.normalized_key_vault_id
     subresource_names              = ["vault"]
   }
 


### PR DESCRIPTION
Avoids issue where '/' is missing from object ID