### PR TITLE
Fix: store task success by default

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -310,7 +310,8 @@ Q_CLUSTER = {
     # The value must be bigger than the time it takes to complete the longest task.
     "retry": int(os.environ.get("Q_RETRY", 300)),
     # Limits the amount of successful task results saved; 0=Unlimited, -1=No success storage
-    "save_limit": int(os.environ.get("Q_SAVE_LIMIT", -1)),
+    # The default is 250
+    "save_limit": int(os.environ.get("Q_SAVE_LIMIT", 250)),
     # The number of seconds a worker is allowed to spend on a task before it’s terminated. Defaults to ... never time out.
     # Timeout must be less than retry value (default 60) and all tasks must complete in less time than the ... retry time.
     "timeout": int(os.environ.get("Q_TIMEOUT", 150)),


### PR DESCRIPTION
Closes #253

## Reviewing

1. Checkout the branch locally, rebuild/reopen devcontainer
2. Run through a vital records flow
3. Run and debug the `Django: QCluster once` profile once, confirm a PDF is generated
4. Log in to the Admin and look at `Tasks > Queued tasks`, confirm an `email` task is present
5. Run and debug the `Django: QCluster once` profile again, confirm an email is sent (either as a file to the local `./inbox` or via Azure to the `VITAL_RECORDS_EMAIL_TO` inbox)