### PR TITLE
Fix: CA.gov logo in header should link to CA.gov

### DIFF
--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -100,7 +100,7 @@
             <div class="section-default border-0">
                 <div class="branding">
                     <div class="header-organization-banner">
-                        <a href="{% url 'core:index' %}">
+                        <a href="https://ca.gov/">
                             <div class="logo-assets">
                                 <img src="https://cdn.cdt.ca.gov/cdt/cagov/cagov-lockup/cagov-lockup-flag/cagov-lockup-flag-gradient/cagov-lockup-flag-gradient.svg"
                                      class="logo-img"


### PR DESCRIPTION
closes #263 

Header logo now links to CA.gov

<img width="1261" height="975" alt="image" src="https://github.com/user-attachments/assets/a3dfa65c-3749-414f-9443-4bd129646eb5" />
