### PR TITLE
Fix: `psycopg` instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "django-google-sso==8.0.0",
     "django-q2==1.8.0",
     "gunicorn==23.0.0",
+    "opentelemetry-instrumentation-psycopg==0.57b0",
     "psycopg[binary,pool]==3.2.9",
     "pypdf==5.9.0",
     "requests==2.32.4",

--- a/tests/pytest/test_monitoring.py
+++ b/tests/pytest/test_monitoring.py
@@ -29,10 +29,13 @@ def test_configure__no_connection_string(mock_configure_azure_monitor):
 @pytest.mark.usefixtures("conn_str")
 def test_configure__with_connection_string(mocker, mock_configure_azure_monitor):
     mock_get_logger = mocker.patch("logging.getLogger")
+    mock_psycopg_instrumentor = mocker.patch("web.monitoring.PsycopgInstrumentor")
 
     configure()
 
     mock_configure_azure_monitor.assert_called_once()
+    mock_psycopg_instrumentor.assert_called_once()
+    mock_psycopg_instrumentor.return_value.instrument.assert_called_once()
     mock_get_logger.assert_has_calls([mocker.call("azure"), mocker.call().setLevel(logging.WARNING)])
     mock_get_logger.assert_has_calls([mocker.call("django"), mocker.call().setLevel(logging.INFO)])
     mock_get_logger.assert_has_calls([mocker.call("web"), mocker.call().setLevel("DEBUG")])

--- a/tests/pytest/test_monitoring.py
+++ b/tests/pytest/test_monitoring.py
@@ -55,3 +55,4 @@ def test_configure__instrumentation_options(mock_configure_azure_monitor):
     _, kwargs = mock_configure_azure_monitor.call_args
     assert kwargs["instrumentation_options"]["fastapi"]["enabled"] is False
     assert kwargs["instrumentation_options"]["flask"]["enabled"] is False
+    assert kwargs["instrumentation_options"]["psycopg2"]["enabled"] is False

--- a/web/monitoring.py
+++ b/web/monitoring.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from azure.monitor.opentelemetry import configure_azure_monitor as _configure_azure_monitor
+from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
 
 
 def configure(log_level: str = "DEBUG"):
@@ -21,6 +22,9 @@ def configure(log_level: str = "DEBUG"):
                 "psycopg2": {"enabled": False},
             },
         )
+
+        # Manually instrument psycopg v3
+        PsycopgInstrumentor().instrument()
 
         # override log levels for some loggers
         logger_levels = {"azure": logging.WARNING, "django": logging.INFO, "web": log_level}

--- a/web/monitoring.py
+++ b/web/monitoring.py
@@ -18,6 +18,7 @@ def configure(log_level: str = "DEBUG"):
             instrumentation_options={
                 "fastapi": {"enabled": False},
                 "flask": {"enabled": False},
+                "psycopg2": {"enabled": False},
             },
         )
 


### PR DESCRIPTION
We are using the newer `psycopg` (v3) package, not the older `psycopg2` that Azure automatically instruments.

This will prevent alerts for exceptions like:

```
Exception occurred when instrumenting: psycopg2
```