### PR TITLE
Chore: copy updates

### DIFF
--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -225,10 +225,10 @@ header {
   }
 
   small.form-help {
-    color: var(--gray-600, #72717c);
     display: block;
     font-weight: 400;
-    margin-top: 4px;
+    line-height: 32px;
+    margin-top: 12px;
   }
 
   .form-group {

--- a/web/vital_records/templates/vital_records/request/confirm.html
+++ b/web/vital_records/templates/vital_records/request/confirm.html
@@ -15,7 +15,7 @@
             </p>
             <hr>
             <h3 class="md m-b-sm">Birth record details</h3>
-            <p>This is the information that will be printed on the replacement birth record.</p>
+            <p>Your record will be searched using the information provided. Please verify it is correct.</p>
             <dl class="m-b-40">
                 <dt>Name</dt>
                 <dd>

--- a/web/vital_records/templates/vital_records/request/statement.html
+++ b/web/vital_records/templates/vital_records/request/statement.html
@@ -26,6 +26,9 @@
                         </p>
                         {{ form.legal_attestation|label_with_required }}
                         {{ form.legal_attestation }}
+                        <small class="form-help">
+                            It is my intent to sign this document electronically and I understand that the electronic signature will be the legal equivalent of having placed my handwritten signature on this form.
+                        </small>
                     </div>
                     {% if form.legal_attestation.errors %}<div class="error">{{ form.legal_attestation.errors }}</div>{% endif %}
                 </div>

--- a/web/vital_records/templates/vital_records/request/statement.html
+++ b/web/vital_records/templates/vital_records/request/statement.html
@@ -6,7 +6,7 @@
     <div class="row">
         <div class="col-lg-10">
             <p class="m-t p-b m-b-sm">
-                To get an authorized copy, you must be the person named on the record or someone legally allowed to request it — like a parent, guardian, or close relative.
+                To get an authorized copy, you must be the person named on the record or someone legally allowed to request it — like a parent, guardian, child, sibling, grandparent or spouse.
             </p>
         </div>
     </div>


### PR DESCRIPTION
Closes #274 

### TODOs 

- [x] On Step 6: Replace "This is the information that will be printed on the replacement birth record" with "Your record will be searched using the information provided. Please verify it is correct."
- [x] Add below signature block: "It is my intent to sign this document electronically and I understand that the electronic signature will be the legal equivalent of having placed my handwritten signature on this form." 
- [x] On Confirm eligibility step: Replace: "To get an authorized copy, you must be the person named on the record or someone legally allowed to request it — like a parent, guardian, or close relative." with "To get an authorized copy, you must be the person named on the record or someone legally allowed to request it — like a parent, guardian, child, sibling, grandparent or spouse."

On that second TODO item, I had to add an element to the page and get its styling in, so here are some screenshots:

<details><summary>Screenshots</summary>

<img width="1920" height="1152" alt="Screenshot from 2025-08-07 17-47-53" src="https://github.com/user-attachments/assets/f0cc20fe-8047-4bec-83c1-eaf861a2357d" />


---

(full page)
<img width="1919" height="1782" alt="Screenshot 2025-08-07 at 17-48-00 Replacement birth record California Digital Disaster Recovery Center" src="https://github.com/user-attachments/assets/4d76609b-3436-4211-b09b-ba1c384f1188" />
</details>