### PR TITLE
Feat: email templates take record type in context

### DIFF
--- a/tests/pytest/vital_records/tasks/test_email.py
+++ b/tests/pytest/vital_records/tasks/test_email.py
@@ -35,6 +35,7 @@ class TestEmailTask:
             "number_of_copies": mock_VitalRecordsRequest.number_of_records,
             "email_address": mock_VitalRecordsRequest.email_address,
             "logo_url": "https://webstandards.ca.gov/wp-content/uploads/sites/8/2024/10/cagov-logo-coastal-flat.png",
+            "request_type": task._format_record_type(mock_VitalRecordsRequest.type),
         }
         mock_render.assert_any_call(EMAIL_TXT_TEMPLATE, expected_ctx)
         mock_render.assert_any_call(EMAIL_HTML_TEMPLATE, expected_ctx)

--- a/web/vital_records/tasks/email.py
+++ b/web/vital_records/tasks/email.py
@@ -21,6 +21,18 @@ class EmailTask(Task):
     def __init__(self, request_id: UUID, package: str):
         super().__init__(request_id=request_id, package=package)
 
+    def _format_record_type(self, record_type: str) -> str:
+        """
+        Checks the value of the record type and returns a
+        string formatted for the email template.
+        """
+        type_format = {
+            "birth": "Birth",
+            "marriage": "Marriage",
+        }
+
+        return type_format.get(record_type)
+
     def handler(self, request_id: UUID, package: str):
         logger.debug(f"Sending request package for: {request_id}")
         request = VitalRecordsRequest.get_with_status(request_id, "packaged")
@@ -29,6 +41,7 @@ class EmailTask(Task):
             "number_of_copies": request.number_of_records,
             "logo_url": "https://webstandards.ca.gov/wp-content/uploads/sites/8/2024/10/cagov-logo-coastal-flat.png",
             "email_address": request.email_address,
+            "request_type": self._format_record_type(request.type),
         }
         text_content = render_to_string(EMAIL_TXT_TEMPLATE, context)
         html_content = render_to_string(EMAIL_HTML_TEMPLATE, context)

--- a/web/vital_records/templates/vital_records/email.html
+++ b/web/vital_records/templates/vital_records/email.html
@@ -13,7 +13,7 @@
         <p>Hello,</p>
         <p>You recently completed an application for the following:</p>
         <p>
-            <strong>Vital Record Type: Birth</strong>
+            <strong>Vital Record Type: {{ request_type }}</strong>
         </p>
         <p>
             <strong>Number of copies: {{ number_of_copies }}</strong>

--- a/web/vital_records/templates/vital_records/email.txt
+++ b/web/vital_records/templates/vital_records/email.txt
@@ -2,7 +2,7 @@ Hello,
 
 You recently completed an application for the following:
 
-Vital Record Type: Birth
+Vital Record Type: {{ request_type }}
 
 Number of copies: {{ number_of_copies }}
 


### PR DESCRIPTION
Closes #292

In this PR, the email templates now use the request type from the vital records request object via the template's context instead of hard coded values. 

Note that this implementation will pass the string `Birth record` or `Marriage record` to the context since we are using [`request.get_type_display()`](https://docs.djangoproject.com/en/5.2/ref/models/instances/#django.db.models.Model.get_FOO_display). Also note that since #315 has been merged, the `type` field of `VitalRecordsRequest` is now populated so we can directly test this PR (at least for the `birth` type).

## Reviewing

1. In your `.env` set `AZURE_COMMUNICATION_CONNECTION_STRING` and `DEFAULT_FROM_EMAIL` to blank
2. Run the `Django: Disaster Recovery` debugger and complete a `Replacement birth record` request
3. Run the `Django: Qcluster` debugger to process the request. This will generate a file named something like `date-id.log` in the `.inbox` folder.
4. Open the `.log` file and confirm that it shows the string `Birth record` for the `Vital Record Type:` heading in both the text and html version of the email