### PR TITLE
Add Back button

### DIFF
--- a/tests/pytest/vital_records/test_mixins.py
+++ b/tests/pytest/vital_records/test_mixins.py
@@ -82,7 +82,9 @@ class TestStepsMixin:
             Steps.preview_and_submit,
         ]
         assert context["step_number"] == expected_step_number
-        assert context["previous_route"] == Routes.app_route(expected_previous_route)
+        assert context["previous_url"] == reverse(
+            Routes.app_route(expected_previous_route), kwargs={"pk": birth_view.object.pk}
+        )
 
     @pytest.mark.parametrize(
         "step_name,expected_step_number,expected_previous_route",
@@ -107,7 +109,9 @@ class TestStepsMixin:
             Steps.preview_and_submit,
         ]
         assert context["step_number"] == expected_step_number
-        assert context["previous_route"] == Routes.app_route(expected_previous_route)
+        assert context["previous_url"] == reverse(
+            Routes.app_route(expected_previous_route), kwargs={"pk": marriage_view.object.pk}
+        )
 
     @pytest.mark.parametrize(
         "step_name,expected_next_route",

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -266,7 +266,7 @@ header {
   form .btn {
     font-size: 18px;
     padding: 8px 16px;
-    margin-right: 20px !important;
+    margin-right: 19.4px !important;
   }
 
   dt {

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -258,9 +258,12 @@ header {
     border-color: var(--gray-200, #d4d4d7);
   }
 
-  form .btn[type="submit"] {
+  form .btn-row {
     margin-top: 40px;
     margin-bottom: 80px;
+  }
+
+  form .btn {
     font-size: 18px;
     padding: 8px 16px;
   }

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -266,7 +266,7 @@ header {
   form .btn {
     font-size: 18px;
     padding: 8px 16px;
-    margin-right: 24px !important;
+    margin-right: 20px !important;
   }
 
   dt {

--- a/web/static/css/styles.css
+++ b/web/static/css/styles.css
@@ -266,6 +266,7 @@ header {
   form .btn {
     font-size: 18px;
     padding: 8px 16px;
+    margin-right: 24px !important;
   }
 
   dt {

--- a/web/vital_records/mixins.py
+++ b/web/vital_records/mixins.py
@@ -75,8 +75,8 @@ class StepsMixin(ContextMixin):
             previous_step_name = step_names[current_index - 1]
             previous_route_name = type_steps[previous_step_name]
 
-        context["previous_route"] = Routes.app_route(previous_route_name)
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
+        previous_route = Routes.app_route(previous_route_name)
+        context["previous_url"] = reverse(previous_route, kwargs={"pk": self.object.pk})
 
         return context
 

--- a/web/vital_records/mixins.py
+++ b/web/vital_records/mixins.py
@@ -76,6 +76,7 @@ class StepsMixin(ContextMixin):
             previous_route_name = type_steps[previous_step_name]
 
         context["previous_route"] = Routes.app_route(previous_route_name)
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
 
         return context
 

--- a/web/vital_records/templates/vital_records/_button_row.html
+++ b/web/vital_records/templates/vital_records/_button_row.html
@@ -1,6 +1,6 @@
 <div class="btn-row">
     <a class="btn btn-outline-primary"
        role="button"
-       href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a>
+       href="{% url previous_route pk=object.id %}">Back</a>
     <button type="submit" class="btn btn-primary">{{ submit_label }}</button>
 </div>

--- a/web/vital_records/templates/vital_records/_button_row.html
+++ b/web/vital_records/templates/vital_records/_button_row.html
@@ -1,7 +1,6 @@
 <div class="btn-row">
-    <!-- djlint:off -->
-      <a class="btn btn-outline-primary"
-         role="button"
-         href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button>
-<!-- djlint:on -->
+    <a class="btn btn-outline-primary"
+       role="button"
+       href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a>
+    <button type="submit" class="btn btn-primary">{{ submit_label }}</button>
 </div>

--- a/web/vital_records/templates/vital_records/_button_row.html
+++ b/web/vital_records/templates/vital_records/_button_row.html
@@ -1,6 +1,6 @@
 <div class="btn-row">
-    <!-- djlint:off -->
-        <a class="btn btn-outline-primary"
-           role="button"
-    href="{% url previous_route pk=object.id %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button><!-- djlint:on -->
+    <a class="btn btn-outline-primary"
+       role="button"
+       href="{{ previous_url }}">Back</a>
+    <button type="submit" class="btn btn-primary">{{ submit_label }}</button>
 </div>

--- a/web/vital_records/templates/vital_records/_button_row.html
+++ b/web/vital_records/templates/vital_records/_button_row.html
@@ -1,0 +1,8 @@
+<div class="btn-row">
+    <!-- djlint:off -->
+                <a href
+                           class="btn btn-outline-primary"
+                           role="button"
+       href="{% url previous_route pk=object.id %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button>
+<!-- djlint:on -->
+</div>

--- a/web/vital_records/templates/vital_records/_button_row.html
+++ b/web/vital_records/templates/vital_records/_button_row.html
@@ -1,6 +1,6 @@
 <div class="btn-row">
-    <a class="btn btn-outline-primary"
-       role="button"
-       href="{% url previous_route pk=object.id %}">Back</a>
-    <button type="submit" class="btn btn-primary">{{ submit_label }}</button>
+    <!-- djlint:off -->
+        <a class="btn btn-outline-primary"
+           role="button"
+    href="{% url previous_route pk=object.id %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button><!-- djlint:on -->
 </div>

--- a/web/vital_records/templates/vital_records/_button_row.html
+++ b/web/vital_records/templates/vital_records/_button_row.html
@@ -1,8 +1,8 @@
 <div class="btn-row">
     <!-- djlint:off -->
-                <a href
-                           class="btn btn-outline-primary"
-                           role="button"
-       href="{% url previous_route pk=object.id %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button>
+                            <a href
+                                       class="btn btn-outline-primary"
+                                       role="button"
+       href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button>
 <!-- djlint:on -->
 </div>

--- a/web/vital_records/templates/vital_records/_button_row.html
+++ b/web/vital_records/templates/vital_records/_button_row.html
@@ -1,8 +1,7 @@
 <div class="btn-row">
     <!-- djlint:off -->
-                            <a href
-                                       class="btn btn-outline-primary"
-                                       role="button"
-       href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button>
+      <a class="btn btn-outline-primary"
+         role="button"
+         href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a><button type="submit" class="btn btn-primary">{{ submit_label }}</button>
 <!-- djlint:on -->
 </div>

--- a/web/vital_records/templates/vital_records/request/confirm.html
+++ b/web/vital_records/templates/vital_records/request/confirm.html
@@ -58,6 +58,6 @@
     <form method="post" class="m-b-40 p-b-lg">
         {% csrf_token %}
         {{ form.as_p }}
-        <button type="submit" class="btn btn-primary m-b-sm">Submit your order</button>
+        {% include "vital_records/_button_row.html" with submit_label="Submit your order" %}
     </form>
 {% endblock flow-container %}

--- a/web/vital_records/templates/vital_records/request/form.html
+++ b/web/vital_records/templates/vital_records/request/form.html
@@ -15,13 +15,14 @@
             {% else %}
                 {% include "vital_records/_two_column_form.html" with form=form fields=form_fields %}
             {% endif %}
-            <div class="btn-row list-unstyled">
-                <a href
-                   class="btn btn-outline-primary"
-                   role="button"
-                   href="{{ previous_route }}">Back</a>
-                <button type="submit" class="btn btn-primary">Next</button>
-            </div>
-        </fieldset>
-    </form>
+            <div class="btn-row">
+                <!-- djlint:off -->
+                            <a href
+                               class="btn btn-outline-primary"
+                               role="button"
+                               href="{{ previous_route }}">Back</a><button type="submit" class="btn btn-primary">Next</button>
+            <!-- djlint:on -->
+        </div>
+    </fieldset>
+</form>
 {% endblock flow-container %}

--- a/web/vital_records/templates/vital_records/request/form.html
+++ b/web/vital_records/templates/vital_records/request/form.html
@@ -15,7 +15,13 @@
             {% else %}
                 {% include "vital_records/_two_column_form.html" with form=form fields=form_fields %}
             {% endif %}
+            <div class="btn-row list-unstyled">
+                <a href
+                   class="btn btn-outline-primary"
+                   role="button"
+                   href="{{ previous_route }}">Back</a>
+                <button type="submit" class="btn btn-primary">Next</button>
+            </div>
         </fieldset>
-        <button type="submit" class="btn btn-primary mt-4">Next</button>
     </form>
 {% endblock flow-container %}

--- a/web/vital_records/templates/vital_records/request/form.html
+++ b/web/vital_records/templates/vital_records/request/form.html
@@ -15,14 +15,7 @@
             {% else %}
                 {% include "vital_records/_two_column_form.html" with form=form fields=form_fields %}
             {% endif %}
-            <div class="btn-row">
-                <!-- djlint:off -->
-                                                <a href
-                                                    class="btn btn-outline-primary"
-                                                    role="button"
-                                            href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a><button type="submit" class="btn btn-primary">Next</button>
-            <!-- djlint:on -->
-        </div>
-    </fieldset>
-</form>
+            {% include "vital_records/_button_row.html" with submit_label="Next" %}
+        </fieldset>
+    </form>
 {% endblock flow-container %}

--- a/web/vital_records/templates/vital_records/request/form.html
+++ b/web/vital_records/templates/vital_records/request/form.html
@@ -17,10 +17,10 @@
             {% endif %}
             <div class="btn-row">
                 <!-- djlint:off -->
-                            <a href
-                               class="btn btn-outline-primary"
-                               role="button"
-                               href="{{ previous_route }}">Back</a><button type="submit" class="btn btn-primary">Next</button>
+                                                <a href
+                                                    class="btn btn-outline-primary"
+                                                    role="button"
+                                            href="{% url previous_route pk=vital_records_request.id as previous_url %}">Back</a><button type="submit" class="btn btn-primary">Next</button>
             <!-- djlint:on -->
         </div>
     </fieldset>

--- a/web/vital_records/templates/vital_records/request/order.html
+++ b/web/vital_records/templates/vital_records/request/order.html
@@ -75,6 +75,6 @@
                 </div>
             </div>
         </fieldset>
-        <button type="submit" class="btn btn-primary">Preview your order</button>
+        {% include "vital_records/_button_row.html" with submit_label="Preview your order" %}
     </form>
 {% endblock flow-container %}

--- a/web/vital_records/templates/vital_records/request/start.html
+++ b/web/vital_records/templates/vital_records/request/start.html
@@ -19,7 +19,9 @@
                     {{ form.fire }}
                     {{ form.fire.errors }}
                 </div>
-                <button type="submit" class="btn btn-primary">Confirm</button>
+                <div class="btn-row">
+                    <button type="submit" class="btn btn-primary">Confirm</button>
+                </div>
             </form>
         </div>
     </div>

--- a/web/vital_records/templates/vital_records/request/statement.html
+++ b/web/vital_records/templates/vital_records/request/statement.html
@@ -32,7 +32,7 @@
                     </div>
                     {% if form.legal_attestation.errors %}<div class="error">{{ form.legal_attestation.errors }}</div>{% endif %}
                 </div>
-                <button type="submit" class="btn btn-primary">Confirm and continue to order</button>
+                {% include "vital_records/_button_row.html" with submit_label="Confirm and continue to order" %}
             </form>
         </div>
     </div>

--- a/web/vital_records/templates/vital_records/request/type.html
+++ b/web/vital_records/templates/vital_records/request/type.html
@@ -15,7 +15,7 @@
                 <p id="confidential-marriage-warning" class="hidden">
                     CDPH does not maintain Confidential Marriage Records. To request a Confidential Marriage Record, please contact the county vital records office that your marriage was registered in.
                 </p>
-                <button type="submit" class="btn btn-primary">Next</button>
+                {% include "vital_records/_button_row.html" with submit_label="Next" %}
             </form>
         </div>
     </div>

--- a/web/vital_records/views/common.py
+++ b/web/vital_records/views/common.py
@@ -15,10 +15,7 @@ from web.vital_records.forms.common import (
     OrderInfoForm,
     SubmitForm,
 )
-from web.vital_records.forms.birth import (
-    CountyForm,
-    ParentsNamesForm,
-)
+from web.vital_records.forms.birth import ParentsNamesForm
 from web.vital_records.mixins import Steps, StepsMixin, ValidateRequestIdMixin
 from web.vital_records.models import VitalRecordsRequest
 from web.vital_records.session import Session
@@ -145,7 +142,6 @@ class NameView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView)
 class CountyView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     template_name = "vital_records/request/form.html"
-    step_name = Steps.county_of_birth
 
     def form_valid(self, form):
         # Move form state to next state

--- a/web/vital_records/views/common.py
+++ b/web/vital_records/views/common.py
@@ -83,8 +83,8 @@ class TypeView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = "Replacement records"
-        context["previous_route"] = Routes.app_route(Routes.request_start)
-        context["previous_url"] = reverse(context["previous_route"])
+        previous_route = Routes.app_route(Routes.request_start)
+        context["previous_url"] = reverse(previous_route)
 
         return context
 
@@ -107,8 +107,8 @@ class StatementView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = f"Replacement {self.object.type} record"
-        context["previous_route"] = Routes.app_route(Routes.request_type)
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
+        previous_route = Routes.app_route(Routes.request_type)
+        context["previous_url"] = reverse(previous_route, kwargs={"pk": self.object.pk})
         return context
 
     def form_valid(self, form):

--- a/web/vital_records/views/common.py
+++ b/web/vital_records/views/common.py
@@ -86,7 +86,8 @@ class TypeView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = "Replacement records"
-        context["previous_route"] = Routes.request_start
+        context["previous_route"] = Routes.app_route(Routes.request_start)
+        context["previous_url"] = reverse(context["previous_route"])
 
         return context
 
@@ -109,7 +110,8 @@ class StatementView(EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = f"Replacement {self.object.type} record"
-        context["previous_route"] = Routes.app_route(Routes.request_start)
+        context["previous_route"] = Routes.app_route(Routes.request_type)
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
         return context
 
     def form_valid(self, form):
@@ -132,6 +134,22 @@ class NameView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView)
     template_name = "vital_records/request/form.html"
     step_name = Steps.name
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
+        context["form_question"] = "What is the name on the birth certificate?"
+        context["form_hint"] = "Please write the information as it appears on the birth certificate."
+        context["font_hint_name"] = "name-hint"
+        form = context["form"]
+
+        context["form_fields"] = [
+            form["first_name"],
+            form["middle_name"],
+            form["last_name"],
+        ]
+
+        return context
+
     def form_valid(self, form):
         # Move form state to next state
         self.object.complete_name()
@@ -143,6 +161,22 @@ class NameView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView)
 class CountyView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     template_name = "vital_records/request/form.html"
+    step_name = Steps.county_of_birth
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
+        context["form_question"] = "What is the county of birth?"
+        context["form_hint"] = (
+            "We only have records for people born in California. If you were born in a different state, please contact the "
+            "Vital Records office in the state you were born to request a new birth record."
+        )
+        context["font_hint_name"] = "county-hint"
+        form = context["form"]
+
+        context["form_fields"] = [form["county_of_event"]]
+
+        return context
 
     def form_valid(self, form):
         # Move form state to next state
@@ -181,6 +215,7 @@ class ParentsNamesView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, Upd
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
         context["form_layout"] = "couples_names_form"
         context["font_hint_name"] = "parents-hint"
         context["form_question"] = "What were the names of the registrant’s parents at the time of the registrant’s birth?"
@@ -218,6 +253,7 @@ class OrderInfoView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, Update
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
         form = context["form"]
         context["name_fields"] = [
             form["order_first_name"],
@@ -257,6 +293,7 @@ class SubmitView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateVie
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
         context["county_display"] = self.get_display_county(context)
         return context
 

--- a/web/vital_records/views/common.py
+++ b/web/vital_records/views/common.py
@@ -184,7 +184,6 @@ class ParentsNamesView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, Upd
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
         context["form_layout"] = "couples_names_form"
         context["font_hint_name"] = "parents-hint"
         context["form_question"] = "What were the names of the registrant’s parents at the time of the registrant’s birth?"
@@ -222,7 +221,6 @@ class OrderInfoView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, Update
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
         form = context["form"]
         context["name_fields"] = [
             form["order_first_name"],
@@ -262,7 +260,6 @@ class SubmitView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateVie
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
         context["county_display"] = self.get_display_county(context)
         return context
 

--- a/web/vital_records/views/common.py
+++ b/web/vital_records/views/common.py
@@ -134,22 +134,6 @@ class NameView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView)
     template_name = "vital_records/request/form.html"
     step_name = Steps.name
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
-        context["form_question"] = "What is the name on the birth certificate?"
-        context["form_hint"] = "Please write the information as it appears on the birth certificate."
-        context["font_hint_name"] = "name-hint"
-        form = context["form"]
-
-        context["form_fields"] = [
-            form["first_name"],
-            form["middle_name"],
-            form["last_name"],
-        ]
-
-        return context
-
     def form_valid(self, form):
         # Move form state to next state
         self.object.complete_name()
@@ -162,21 +146,6 @@ class CountyView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateVie
     model = VitalRecordsRequest
     template_name = "vital_records/request/form.html"
     step_name = Steps.county_of_birth
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
-        context["form_question"] = "What is the county of birth?"
-        context["form_hint"] = (
-            "We only have records for people born in California. If you were born in a different state, please contact the "
-            "Vital Records office in the state you were born to request a new birth record."
-        )
-        context["font_hint_name"] = "county-hint"
-        form = context["form"]
-
-        context["form_fields"] = [form["county_of_event"]]
-
-        return context
 
     def form_valid(self, form):
         # Move form state to next state

--- a/web/vital_records/views/marriage.py
+++ b/web/vital_records/views/marriage.py
@@ -2,6 +2,7 @@ from web.vital_records.forms.birth import CountyForm
 from web.vital_records.forms.marriage import NameForm
 from web.vital_records.mixins import Steps
 from web.vital_records.views import common
+from django.urls import reverse
 
 
 class NameView(common.NameView):
@@ -33,6 +34,7 @@ class NameView(common.NameView):
         ]
         context["person_2_label"] = "Second person"
         context["person_2_labelid"] = "person_2_helptext"
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
 
         return context
 
@@ -54,6 +56,7 @@ class CountyView(common.CountyView):
 
         form = context["form"]
         context["form_fields"] = [form["county_of_event"]]
+        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
 
         return context
 

--- a/web/vital_records/views/marriage.py
+++ b/web/vital_records/views/marriage.py
@@ -34,7 +34,6 @@ class NameView(common.NameView):
         ]
         context["person_2_label"] = "Second person"
         context["person_2_labelid"] = "person_2_helptext"
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
 
         return context
 
@@ -56,7 +55,6 @@ class CountyView(common.CountyView):
 
         form = context["form"]
         context["form_fields"] = [form["county_of_event"]]
-        context["previous_url"] = reverse(context["previous_route"], kwargs={"pk": self.object.pk})
 
         return context
 

--- a/web/vital_records/views/marriage.py
+++ b/web/vital_records/views/marriage.py
@@ -2,7 +2,6 @@ from web.vital_records.forms.birth import CountyForm
 from web.vital_records.forms.marriage import NameForm
 from web.vital_records.mixins import Steps
 from web.vital_records.views import common
-from django.urls import reverse
 
 
 class NameView(common.NameView):


### PR DESCRIPTION
closes #277 

## What this PR does
- Creates an includes called Button Row that will add a Back/Next. The Next label is customizable. 
- [x] Add a back button on the `form.html` template, wired up as an `a href` with role of `button` that routes to `previous_route`.
- [x] Adds back button includes manually to sworn statement, type, order and confirm pages. The select fire page does not have a Back button.
