### PR TITLE
Fix: email subject line to show record type

### DIFF
--- a/web/vital_records/tasks/email.py
+++ b/web/vital_records/tasks/email.py
@@ -46,7 +46,7 @@ class EmailTask(Task):
         text_content = render_to_string(EMAIL_TXT_TEMPLATE, context)
         html_content = render_to_string(EMAIL_HTML_TEMPLATE, context)
         email = EmailMultiAlternatives(
-            subject="Completed: Birth Record Request",
+            subject=f"Completed: {self._format_record_type(request.type)} Record Request",
             body=text_content,
             to=[settings.VITAL_RECORDS_EMAIL_TO],
         )


### PR DESCRIPTION
Closes #332

## Reviewing

1. In your `.env` set `AZURE_COMMUNICATION_CONNECTION_STRING` and `DEFAULT_FROM_EMAIL` to blank
2. Run the `Django: Disaster Recovery` debugger and complete a `Replacement birth record` and `Replacement marriage record` request
3. Run the `Django: Qcluster` debugger to process the requests. This will generate a file named something like `date-id.log` in the `.inbox` folder for each request
4. Open each `.log` file and confirm that they show the string `Completed: Birth Record Request` for the birth request and `Completed: Marriage Record Request` for the marriage request in the subject line