### PR TITLE
Fix: pin `ubuntu-22.04` runner for build and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [tests-pytest]
     if: (!cancelled())
     environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
@@ -89,7 +89,7 @@ jobs:
             ghcr.io/${{ steps.repo.outputs.lower }}:${{ github.sha }}
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
     permissions:
@@ -151,7 +151,7 @@ jobs:
           done
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: deploy
     if: ${{ github.ref_type == 'tag' && !contains(github.ref, '-rc') }}
     permissions:


### PR DESCRIPTION
`ubuntu-latest` went from 22.04 to 24.04 in the last few weeks and we've seen about 30x slowdown in build times since then.

See e.g. this run (on 22.04) taking ~5 mins: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/actions/runs/16950235801/job/48041152955

Vs. this run (on 24.04) taking ~30 mins: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/actions/runs/17076099728/job/48417876227

This is attributable to building in emulation for the `arm64` platform, where the 22.04 toolchain seemed to handle this fine, and something in 24.04 causes a massive drop in performance of the emulated build steps.

We'll pin to 22.04 for a while and keep an eye on announcements from GitHub etc. as to when we might want to bump back up to 24.04 (or latest)