### PR TITLE
Feat: validate type in URL

### DIFF
--- a/web/vital_records/mixins.py
+++ b/web/vital_records/mixins.py
@@ -14,6 +14,18 @@ class DisableFieldsMixin:
                 field.disabled = True
 
 
+class ValidateTypeMixin:
+    def dispatch(self, request, *args, **kwargs):
+        path = self.request.path
+        # assumes URL is in the form of '/vital-records/request/<record_type>'
+        record_type = path.split("/")[3]
+
+        if self.type and self.type == record_type:
+            return super().dispatch(request, *args, **kwargs)
+        else:
+            return HttpResponseForbidden()
+
+
 class ValidateRequestIdMixin:
     def dispatch(self, request, *args, **kwargs):
         session = Session(request)

--- a/web/vital_records/mixins.py
+++ b/web/vital_records/mixins.py
@@ -20,7 +20,8 @@ class ValidateTypeMixin:
         # assumes URL is in the form of '/vital-records/request/<record_type>'
         record_type = path.split("/")[3]
 
-        if self.type and self.type == record_type:
+        record_request = self.get_object()
+        if record_request.type and record_request.type == record_type:
             return super().dispatch(request, *args, **kwargs)
         else:
             return HttpResponseForbidden()

--- a/web/vital_records/urls.py
+++ b/web/vital_records/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path("request/birth/<uuid:pk>/name", birth.NameView.as_view(), name=Routes.birth_request_name),
     path("request/birth/<uuid:pk>/county", birth.CountyView.as_view(), name=Routes.birth_request_county),
     path("request/birth/<uuid:pk>/dob", birth.DateOfBirthView.as_view(), name=Routes.birth_request_dob),
-    path("request/birth/<uuid:pk>/parents", common.ParentsNamesView.as_view(), name=Routes.birth_request_parents),
+    path("request/birth/<uuid:pk>/parents", birth.ParentsNamesView.as_view(), name=Routes.birth_request_parents),
     # marriage flow URLs
     path("request/marriage/<uuid:pk>/name", marriage.NameView.as_view(), name=Routes.marriage_request_name),
     path("request/marriage/<uuid:pk>/marriage", marriage.CountyView.as_view(), name=Routes.marriage_request_county),

--- a/web/vital_records/views/birth.py
+++ b/web/vital_records/views/birth.py
@@ -1,6 +1,12 @@
-from web.vital_records.forms.birth import CountyForm, NameForm
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+from django.views.generic.edit import UpdateView
+
+from web.core.views import EligibilityMixin
+from web.vital_records.forms.birth import CountyForm, NameForm, ParentsNamesForm
+from web.vital_records.models import VitalRecordsRequest
 from web.vital_records.views import common
-from web.vital_records.mixins import Steps, ValidateTypeMixin
+from web.vital_records.mixins import Steps, StepsMixin, ValidateRequestIdMixin, ValidateTypeMixin
 
 
 class NameView(ValidateTypeMixin, common.NameView):
@@ -50,5 +56,35 @@ class DateOfBirthView(ValidateTypeMixin, common.DateOfEventView):
         context["font_hint_name"] = "dob-hint"
         context["form_question"] = "What is the date of birth?"
         context["form_hint"] = "If you’re not sure, enter your approximate date of birth."
+
+        return context
+
+
+@method_decorator(never_cache, name="dispatch")
+class ParentsNamesView(ValidateTypeMixin, StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView):
+    model = VitalRecordsRequest
+    form_class = ParentsNamesForm
+    template_name = "vital_records/request/form.html"
+    step_name = Steps.parents_names
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form_layout"] = "couples_names_form"
+        context["font_hint_name"] = "parents-hint"
+        context["form_question"] = "What were the names of the registrant’s parents at the time of the registrant’s birth?"
+        context["form_hint"] = "Please write the information as it appears on the birth certificate."
+        form = context["form"]
+        context["person_1_fields"] = [
+            form["person_1_first_name"],
+            form["person_1_last_name"],
+        ]
+        context["person_1_label"] = "Parent 1"
+        context["person_1_labelid"] = "parent_1_helptext"
+        context["person_2_fields"] = [
+            form["person_2_first_name"],
+            form["person_2_last_name"],
+        ]
+        context["person_2_label"] = "Parent 2"
+        context["person_2_labelid"] = "parent_2_helptext"
 
         return context

--- a/web/vital_records/views/birth.py
+++ b/web/vital_records/views/birth.py
@@ -1,9 +1,9 @@
 from web.vital_records.forms.birth import CountyForm, NameForm
 from web.vital_records.views import common
-from web.vital_records.mixins import Steps
+from web.vital_records.mixins import Steps, ValidateTypeMixin
 
 
-class NameView(common.NameView):
+class NameView(ValidateTypeMixin, common.NameView):
     form_class = NameForm
 
     def get_context_data(self, **kwargs):
@@ -22,7 +22,7 @@ class NameView(common.NameView):
         return context
 
 
-class CountyView(common.CountyView):
+class CountyView(ValidateTypeMixin, common.CountyView):
     form_class = CountyForm
     step_name = Steps.county_of_birth
 
@@ -41,7 +41,7 @@ class CountyView(common.CountyView):
         return context
 
 
-class DateOfBirthView(common.DateOfEventView):
+class DateOfBirthView(ValidateTypeMixin, common.DateOfEventView):
     step_name = Steps.date_of_birth
 
     def get_context_data(self, **kwargs):

--- a/web/vital_records/views/common.py
+++ b/web/vital_records/views/common.py
@@ -18,7 +18,7 @@ from web.vital_records.forms.common import (
     SubmitForm,
 )
 from web.vital_records.forms.birth import ParentsNamesForm
-from web.vital_records.mixins import Steps, StepsMixin, ValidateRequestIdMixin
+from web.vital_records.mixins import Steps, StepsMixin, ValidateRequestIdMixin, ValidateTypeMixin
 from web.vital_records.models import VitalRecordsRequest
 from web.vital_records.session import Session
 
@@ -144,7 +144,7 @@ class DateOfEventView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, Upda
 
 
 @method_decorator(never_cache, name="dispatch")
-class ParentsNamesView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView):
+class ParentsNamesView(ValidateTypeMixin, StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView):
     model = VitalRecordsRequest
     form_class = ParentsNamesForm
     template_name = "vital_records/request/form.html"

--- a/web/vital_records/views/common.py
+++ b/web/vital_records/views/common.py
@@ -17,8 +17,7 @@ from web.vital_records.forms.common import (
     OrderInfoForm,
     SubmitForm,
 )
-from web.vital_records.forms.birth import ParentsNamesForm
-from web.vital_records.mixins import Steps, StepsMixin, ValidateRequestIdMixin, ValidateTypeMixin
+from web.vital_records.mixins import Steps, StepsMixin, ValidateRequestIdMixin
 from web.vital_records.models import VitalRecordsRequest
 from web.vital_records.session import Session
 
@@ -141,36 +140,6 @@ class DateOfEventView(StepsMixin, EligibilityMixin, ValidateRequestIdMixin, Upda
     form_class = DateOfEventForm
     template_name = "vital_records/request/form.html"
     context_object_name = "vital_request"
-
-
-@method_decorator(never_cache, name="dispatch")
-class ParentsNamesView(ValidateTypeMixin, StepsMixin, EligibilityMixin, ValidateRequestIdMixin, UpdateView):
-    model = VitalRecordsRequest
-    form_class = ParentsNamesForm
-    template_name = "vital_records/request/form.html"
-    step_name = Steps.parents_names
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["form_layout"] = "couples_names_form"
-        context["font_hint_name"] = "parents-hint"
-        context["form_question"] = "What were the names of the registrant’s parents at the time of the registrant’s birth?"
-        context["form_hint"] = "Please write the information as it appears on the birth certificate."
-        form = context["form"]
-        context["person_1_fields"] = [
-            form["person_1_first_name"],
-            form["person_1_last_name"],
-        ]
-        context["person_1_label"] = "Parent 1"
-        context["person_1_labelid"] = "parent_1_helptext"
-        context["person_2_fields"] = [
-            form["person_2_first_name"],
-            form["person_2_last_name"],
-        ]
-        context["person_2_label"] = "Parent 2"
-        context["person_2_labelid"] = "parent_2_helptext"
-
-        return context
 
 
 @method_decorator(never_cache, name="dispatch")

--- a/web/vital_records/views/marriage.py
+++ b/web/vital_records/views/marriage.py
@@ -1,9 +1,9 @@
 from web.vital_records.forms.marriage import CountyForm, NameForm
-from web.vital_records.mixins import Steps
+from web.vital_records.mixins import Steps, ValidateTypeMixin
 from web.vital_records.views import common
 
 
-class NameView(common.NameView):
+class NameView(ValidateTypeMixin, common.NameView):
     form_class = NameForm
 
     def get_context_data(self, **kwargs):
@@ -36,7 +36,7 @@ class NameView(common.NameView):
         return context
 
 
-class CountyView(common.CountyView):
+class CountyView(ValidateTypeMixin, common.CountyView):
     form_class = CountyForm
     step_name = Steps.county_of_marriage
 
@@ -57,7 +57,7 @@ class CountyView(common.CountyView):
         return context
 
 
-class DateOfMarriageView(common.DateOfEventView):
+class DateOfMarriageView(ValidateTypeMixin, common.DateOfEventView):
     step_name = Steps.date_of_marriage
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
As a part of adding the marriage flow, we introduced a path segment that represents the type of record.

For steps specific to the birth flow, the URL path will look like `/vital-records/request/birth/<id>/...`
For steps specific to the marriage flow, it will look like `/vital-records/request/marriage/<id>/...`

Before this PR, it was possible for the user to manually edit the URL and see the step for that type of flow rather than the one they actually picked.

For example,
- start the Birth record flow
- on the Name step, edit your URL to say `marriage` instead of `birth`
- see Marriage Name form in a Birth Records Request flow:
<img width="1920" height="1152" alt="image" src="https://github.com/user-attachments/assets/3c15748f-cc6a-407d-b98a-4fb46997273b" />

- filling out and submitting this Marriage Name form would save the `First Person` and `Second Person` names as the "Parent 1" and "Parent 2" names in the `VitalRecordsRequest` object in the backend


This PR introduces a mixin to validate the type from the URL. If it doesn't match the `type` on the `VitalRecordsRequest` (which was set during the "Which record would you like to replace?" screen), then we return a 403 response.