### PR TITLE
Chore: clean up telemetry log search alerts

### DIFF
--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -20,7 +20,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "app_error" {
 
   criteria {
     query     = <<-QUERY
-      union exceptions, (traces | where severityLevel >= 3)
+      union (exceptions | where exceptionType !has "ServiceResponseError"), (traces | where severityLevel >= 3)
     QUERY
     operator  = "GreaterThan"
     threshold = 0


### PR DESCRIPTION
Closes #281

In this PR we exclude exceptions of type `ServiceResponseError` from the alert criteria so that we can reduce noise and focus on problems with our application rather than the monitoring service. We use the `has` string operator following the [documented best practices](https://learn.microsoft.com/en-us/kusto/query/best-practices?view=azure-data-explorer#in-short).

**Original query:**
<img width="532" height="340" alt="image" src="https://github.com/user-attachments/assets/06ec22a5-2004-4891-b1e6-cbf324aba712" />

**Updated query:**
<img width="539" height="313" alt="image" src="https://github.com/user-attachments/assets/d4d7a6af-a866-4ebf-babd-22070747173e" />

