### PR TITLE
Fix: remove multi-platform CI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [tests-pytest]
     if: (!cancelled())
     environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
@@ -89,7 +89,7 @@ jobs:
             ghcr.io/${{ steps.repo.outputs.lower }}:${{ github.sha }}
 
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
     permissions:
@@ -151,7 +151,7 @@ jobs:
           done
 
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: deploy
     if: ${{ github.ref_type == 'tag' && !contains(github.ref, '-rc') }}
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,9 +52,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -76,7 +73,7 @@ jobs:
       - name: Build, tag, and push image to GitHub Container Registry
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           builder: ${{ steps.buildx.outputs.name }}
           build-args: GIT-SHA=${{ github.sha }}
           cache-from: ${{ steps.cache_params.outputs.cache_from_args }}


### PR DESCRIPTION
Closes #373 

The QEMU emulation is the more likely cause of long build times in the deploy workflow than any runner/build software config.

Since Azure only needs the linux/amd64 architecture for the Container App, and since we don't need a multi-platform image locally from GHCR, this should simplify and streamline the CI deployment workflow.

Also reverts the builder image change from #336