### PR TITLE
Fix: Log Search alert rule

### DIFF
--- a/terraform/alerts.tf
+++ b/terraform/alerts.tf
@@ -20,7 +20,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "app_error" {
 
   criteria {
     query     = <<-QUERY
-      union (exceptions | where exceptionType !has "ServiceResponseError"), (traces | where severityLevel >= 3)
+      union (exceptions | where type !has "ServiceResponseError"), (traces | where severityLevel >= 3)
     QUERY
     operator  = "GreaterThan"
     threshold = 0


### PR DESCRIPTION
Closes #377 

The Log Search alert rule query defined in Terraform actually runs in the Application Insights resource, and the column there is named "type", not "exceptionType".

## Notes

The same exceptions data are [stored in two places in Azure](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete#exception-telemetry):

- Application Insights resource (on the left nav bar, under `Monitoring` - `Logs`)
  - Table: `exceptions`
  - Columns: `problemId`, `type`, ...

- Log Analytics workspace resource (on the left nav bar, under `Logs`)
  - Table: `AppExceptions`
  - Columns: `ProblemId`, `ExceptionType`, ...
  
Log Search alert queries run against the Application Insights resource.