### PR TITLE
Fix: links in admonition blocks

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -17,3 +17,6 @@ MD024: false
 # Allow mixing code block and fenced code regions
 # Useful for pages with admonitions and fenced code blocks
 MD046: false
+
+# Allow using link reference definitions in admonitions
+MD053: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -14,6 +14,9 @@ MD033: false
 # Allow duplicate headers
 MD024: false
 
+# Allow using code blocks without specifying a language
+MD040: false
+
 # Allow mixing code block and fenced code regions
 # Useful for pages with admonitions and fenced code blocks
 MD046: false

--- a/docs/guides/hotfix.md
+++ b/docs/guides/hotfix.md
@@ -7,8 +7,6 @@ If `main` contains in-progress work that is not yet ready for a release but a si
 is needed in production, a separate process to test the changes before deploying to production must be undertaken.
 This is called a hotfix release. Typically, a hotfix release involves a simple code change that can be quickly implemented, in contrast to a [rollback release](./rollback.md), which generally requires more complex code changes which take more time to implement.
 
-[Start a new Release on Github](https://github.com/cal-itp/benefits/issues/new?labels=release&template=release.yml&title=Make+a+Release){ .md-button }
-
 ## 0. Create a temporary hotfix branch from the latest release tag
 
 ```bash

--- a/docs/guides/infrastructure.md
+++ b/docs/guides/infrastructure.md
@@ -72,7 +72,7 @@ These steps were followed when setting up our Azure deployment for the first tim
 
 - CDT team creates the [resources that they own](../reference/infrastructure.md#ownership)
 - `terraform apply`
-- Set up Slack notifications by [creating a Slack email](https://slack.com/help/articles/206819278-Send-emails-to-Slack) for the [#notify-benefits](https://cal-itp.slack.com/archives/C022HHSEE3F) channel, then [setting it as a Secret in the Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault) named `slack-benefits-notify-email`
-- Set required [App Service configuration](../configuration/environment-variables.md) and [configuration](../configuration/data.md) by setting values in Key Vault (the mapping is defined in [app_service.tf](https://github.com/cal-itp/benefits/blob/main/terraform/app_service.tf))
+- Set up Slack notifications by [creating a Slack email](https://slack.com/help/articles/206819278-Send-emails-to-Slack) for the `#shared-cdt-ddrc-notify` channel, then [setting it as a Secret in the Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault) named `slack-ddrc-notify-email`
+- Set required Container App configuration by setting values in Key Vault (the mapping is defined in [app_web.tf](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/terraform/modules/application/app_web.tf) and [modules.tf](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/terraform/modules.tf))
 
 This is not a complete step-by-step guide; more a list of things to remember.

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -7,12 +7,10 @@ A release is made by pushing an annotated tag. The name of the tag must use
 the version number format mentioned below. This kicks off a deployment to the
 production environment and creates a GitHub release. The version number for the
 app and the release will be the tag’s name. More details on the deployment steps
-can be found under [Workflows](./workflows.md).
+can be found in the [Deploy Workflow](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/.github/workflows/deploy.yml).
 
-The list of releases can be found on the [repository Releases page](https://github.com/cal-itp/benefits/tags)
+The list of releases can be found on the [repository Releases page](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/tags)
 on GitHub.
-
-[Start a new Release on Github](https://github.com/cal-itp/benefits/issues/new?labels=release&template=release.yml&title=Make+a+Release){ .md-button }
 
 ## 0. Decide on the new version number
 

--- a/docs/guides/rollback.md
+++ b/docs/guides/rollback.md
@@ -6,8 +6,6 @@ This list outlines the manual steps needed to make a rollback of the
 If a change is deployed to the app that makes it fail to start, making a rollback
 will deploy the app to a known working state again.
 
-[Start a new Release on Github](https://github.com/cal-itp/benefits/issues/new?labels=release&template=release.yml&title=Make+a+Release){ .md-button }
-
 ## 0. Create a release tag on the commit associated with the last known good release tag
 
 ```bash

--- a/docs/reference/application-logic.md
+++ b/docs/reference/application-logic.md
@@ -78,7 +78,7 @@ The CDT Identity Gateway transforms PII from Login.gov into anonymized boolean c
 
 !!! example "Entrypoint"
 
-    [`cdt-ods-disaster-recovery/web/vital_records/views/common.py`][oauth-eligibility-views]
+    [`cdt-ods-disaster-recovery/web/vital_records/views/common.py`][order-record-views]
 
 !!! example "Key supporting files"
 
@@ -121,7 +121,7 @@ In this phase, DDRC verifies the user's claims by using claims previously stored
 
 !!! example "Entrypoint"
 
-    [`cdt-ods-disaster-recovery/web/vital_records/views/common.py`][oauth-eligibility-views]
+    [`cdt-ods-disaster-recovery/web/vital_records/views/common.py`][order-record-views]
 
 !!! example "Key supporting files"
 
@@ -228,9 +228,8 @@ email->>user: email confirmation of vital records request PDF application submit
     deactivate email
 ```
 
-[core-middleware]: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/core/middleware.py <!-- markdownlint-disable-line MD034 -->
-[eligibility-verify]: https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py <!-- markdownlint-disable-line MD034 -->
-[order-record-views]: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/views/common.py <!-- markdownlint-disable-line MD034 -->
-[oauth-client]: https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/client.py <!-- markdownlint-disable-line MD034 -->
-[oauth-hooks]: https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/hooks.py <!-- markdownlint-disable-line MD034 -->
-[oauth-eligibility-views]: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/views/common.py <!-- markdownlint-disable-line MD034 -->
+[core-middleware]: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/core/middleware.py
+[eligibility-verify]: https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/views.py
+[order-record-views]: https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/views/common.py
+[oauth-client]: https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/client.py
+[oauth-hooks]: https://github.com/Office-of-Digital-Services/django-cdt-identity/blob/main/cdt_identity/hooks.py

--- a/docs/reference/application-logic.md
+++ b/docs/reference/application-logic.md
@@ -200,6 +200,7 @@ The DDRC application generates a PDF of the vital records request and emails it 
 !!! example "Async tasks"
 
     [`cdt-ods-disaster-recovery/web/vital_records/tasks/package.py`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/tasks/package.py)
+
     [`cdt-ods-disaster-recovery/web/vital_records/tasks/email.py`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/tasks/email.py)
 
 ```mermaid

--- a/docs/reference/commits-branches-merging.md
+++ b/docs/reference/commits-branches-merging.md
@@ -4,7 +4,7 @@
 
 This project enforces the [Conventional Commits][conventional-commits] style for commit message formatting:
 
-```<!-- markdownlint-disable-line MD040 -->
+```
 <type>[(optional-scope)]: <description>
 
 [optional body]


### PR DESCRIPTION
Follow-up to #346

This PR makes several fixes/cleanups to the initial content. These include:

- Remove inline Markdown linter disable commands for links in admonitions since these were not being rendered correctly
- Clean up some dead links
- Update some content that was not accurate initially
