### PR TITLE
Chore: add Death as a type for the email task

### DIFF
--- a/tests/pytest/vital_records/tasks/test_email.py
+++ b/tests/pytest/vital_records/tasks/test_email.py
@@ -23,7 +23,21 @@ class TestEmailTask:
         assert task.kwargs["package"] == "package"
         assert task.started is False
 
-    @pytest.mark.parametrize("request_type, request_type_formatted", [("birth", "Birth"), ("marriage", "Marriage")])
+    @pytest.mark.parametrize(
+        "record_type, expected_output",
+        [
+            ("birth", "Birth"),
+            ("marriage", "Marriage"),
+            ("death", "Death"),
+            ("invalid_type", None),
+        ],
+    )
+    def test__format_record_type(self, task, record_type, expected_output):
+        assert task._format_record_type(record_type) == expected_output
+
+    @pytest.mark.parametrize(
+        "request_type, request_type_formatted", [("birth", "Birth"), ("marriage", "Marriage"), ("death", "Death")]
+    )
     def test_handler(
         self,
         settings,

--- a/web/vital_records/tasks/email.py
+++ b/web/vital_records/tasks/email.py
@@ -29,6 +29,7 @@ class EmailTask(Task):
         type_format = {
             "birth": "Birth",
             "marriage": "Marriage",
+            "death": "Death",
         }
 
         return type_format.get(record_type)
@@ -36,17 +37,18 @@ class EmailTask(Task):
     def handler(self, request_id: UUID, package: str):
         logger.debug(f"Sending request package for: {request_id}")
         request = VitalRecordsRequest.get_with_status(request_id, "packaged")
+        request_type = self._format_record_type(request.type)
 
         context = {
             "number_of_copies": request.number_of_records,
             "logo_url": "https://webstandards.ca.gov/wp-content/uploads/sites/8/2024/10/cagov-logo-coastal-flat.png",
             "email_address": request.email_address,
-            "request_type": self._format_record_type(request.type),
+            "request_type": request_type,
         }
         text_content = render_to_string(EMAIL_TXT_TEMPLATE, context)
         html_content = render_to_string(EMAIL_HTML_TEMPLATE, context)
         email = EmailMultiAlternatives(
-            subject=f"Completed: {self._format_record_type(request.type)} Record Request",
+            subject=f"Completed: {request_type} Record Request",
             body=text_content,
             to=[settings.VITAL_RECORDS_EMAIL_TO],
         )


### PR DESCRIPTION
Closes #388

This PR adds the `death` type to the `email` task so that it can support death certificate vital records requests. It also makes a small refactor to avoid duplicate calls to the `_format_record_type` function and adds a test for `_format_record_type` that was missing.

## Reviewing

1. In your `.env` set `AZURE_COMMUNICATION_CONNECTION_STRING` and `DEFAULT_FROM_EMAIL` to blank
2. Run the `Django: Disaster Recovery` debugger and complete a `Replacement death record` request
3. Run the `Django: Qcluster` debugger to process the request. This will generate a file named something like `date-id.log` in the `.inbox` folder.
4. Open the `.log` file and confirm that it shows the string `Death` for the `Vital Record Type:` heading in both the text and html version of the email. Also confirm that `Completed: Death Record Request` appears in the subject line.