### PR TITLE
Fix: form_hint_name

### DIFF
--- a/web/vital_records/views/birth.py
+++ b/web/vital_records/views/birth.py
@@ -16,7 +16,7 @@ class NameView(ValidateTypeMixin, common.NameView):
         context = super().get_context_data(**kwargs)
         context["form_question"] = "What is the name on the birth certificate?"
         context["form_hint"] = "Please write the information as it appears on the birth certificate."
-        context["font_hint_name"] = "name-hint"
+        context["form_hint_name"] = "name-hint"
         form = context["form"]
 
         context["form_fields"] = [
@@ -39,7 +39,7 @@ class CountyView(ValidateTypeMixin, common.CountyView):
             "We only have records for people born in California. If you were born in a different state, please contact the "
             "Vital Records office in the state you were born to request a new birth record."
         )
-        context["font_hint_name"] = "county-hint"
+        context["form_hint_name"] = "county-hint"
         form = context["form"]
 
         context["form_fields"] = [form["county_of_event"]]
@@ -53,7 +53,7 @@ class DateOfBirthView(ValidateTypeMixin, common.DateOfBirthView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form_layout"] = "date_form"
-        context["font_hint_name"] = "dob-hint"
+        context["form_hint_name"] = "dob-hint"
         context["form_question"] = "What is the date of birth?"
         context["form_hint"] = "If you’re not sure, enter your approximate date of birth."
 
@@ -70,7 +70,7 @@ class ParentsNamesView(ValidateTypeMixin, StepsMixin, EligibilityMixin, Validate
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form_layout"] = "couples_names_form"
-        context["font_hint_name"] = "parents-hint"
+        context["form_hint_name"] = "parents-hint"
         context["form_question"] = "What were the names of the registrant’s parents at the time of the registrant’s birth?"
         context["form_hint"] = "Please write the information as it appears on the birth certificate."
         form = context["form"]

--- a/web/vital_records/views/marriage.py
+++ b/web/vital_records/views/marriage.py
@@ -13,7 +13,7 @@ class NameView(ValidateTypeMixin, common.NameView):
             "What are the names of the First Person and Second Person as they appear on the marriage record?"
         )
         context["form_hint"] = "Please write the information as it appears on the marriage certificate."
-        context["font_hint_name"] = "name-hint"
+        context["form_hint_name"] = "name-hint"
 
         form = context["form"]
         context["person_1_fields"] = [
@@ -63,7 +63,7 @@ class DateOfMarriageView(ValidateTypeMixin, common.DateOfEventView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form_layout"] = "date_form"
-        context["font_hint_name"] = "marriage-date-hint"
+        context["form_hint_name"] = "marriage-date-hint"
         context["form_question"] = "What was the date of the marriage?"
         context["form_hint"] = "If you’re not sure, enter your approximate date of marriage."
 


### PR DESCRIPTION
Closes #400 

Simple typo fix.

I took some time to look back at these notes I wrote in https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/pull/402#issuecomment-3313609299:

> Side note: I read more about `aria-describedby` / looked at the accessibility tree for our pages, and it looks like setting `aria-describedby` on `fieldset` doesn't actually do anything. In other words, the `form_hint` copy does not appear as a `description` on any object in the accessibility tree. This is a separate issue from what you're asking about. (But maybe it is relevant because if we remove our incorrect / non-functioning use of it, we don't have to worry about setting it?)

I'm not sure if I was looking in the wrong place in the accessibility tree or maybe it was actually this very bug that was causing me to not see the accessible description being set on the fieldset. I'm seeing it now, so just wanted to close the loop on this: the way we're setting `aria-describedby` on the `fieldset` is fine.

<img width="1682" height="1004" alt="Screenshot from 2025-09-24 17-25-16" src="https://github.com/user-attachments/assets/ae6b57c3-61e7-438f-af4f-632bbc47ff01" />
