### PR TITLE
Fix: footer external links

### DIFF
--- a/web/core/templates/core/base.html
+++ b/web/core/templates/core/base.html
@@ -130,13 +130,13 @@
                     </a>
                     <ul class="footer-links">
                         <li>
-                            <a href="{% url 'core:index' %}">Conditions of use</a>
+                            <a href="https://www.ca.gov/legal/conditions-of-use/">Conditions of use</a>
                         </li>
                         <li>
-                            <a href="{% url 'core:index' %}">Privacy policy</a>
+                            <a href="https://www.ca.gov/legal/privacy-policy/">Privacy policy</a>
                         </li>
                         <li>
-                            <a href="{% url 'core:index' %}">Accessibility</a>
+                            <a href="https://www.ca.gov/legal/accessibility/">Accessibility</a>
                         </li>
                     </ul>
                     <ul class="socialsharer-container">


### PR DESCRIPTION
Closes #407 

This PR updates the footer links to use the same URLs as the ones in the https://ca.gov footer for
- Conditions of use
- Privacy policy
- Accessibility