### PR TITLE
Feat: send confirmation email to requestor

### DIFF
--- a/tests/pytest/vital_records/tasks/test_email.py
+++ b/tests/pytest/vital_records/tasks/test_email.py
@@ -35,6 +35,26 @@ class TestEmailTask:
     def test__format_record_type(self, task, record_type, expected_output):
         assert task._format_record_type(record_type) == expected_output
 
+    def test__create_base_email(self, mocker, task):
+        """Tests that the base email object is created correctly."""
+        mock_EmailMultiAlternatives = mocker.patch("web.vital_records.tasks.email.EmailMultiAlternatives")
+        mock_email_instance = mock_EmailMultiAlternatives.return_value
+
+        subject = "Test Subject"
+        to_address = ["test@example.com"]
+        text_content = "This is the text content."
+        html_content = "<p>This is the HTML content.</p>"
+
+        result = task._create_base_email(subject, to_address, text_content, html_content)
+
+        mock_EmailMultiAlternatives.assert_called_once_with(
+            subject=subject,
+            body=text_content,
+            to=to_address,
+        )
+        mock_email_instance.attach_alternative.assert_called_once_with(html_content, "text/html")
+        assert result == mock_email_instance
+
     @pytest.mark.parametrize(
         "request_type, request_type_formatted", [("birth", "Birth"), ("marriage", "Marriage"), ("death", "Death")]
     )
@@ -51,13 +71,26 @@ class TestEmailTask:
         mock_inst = mocker.MagicMock(email_address="email@example.com", number_of_records=1, type=request_type)
         mock_VitalRecordsRequest.get_with_status.return_value = mock_inst
         mock_render = mocker.patch("web.vital_records.tasks.email.render_to_string", return_value="email body")
-        mock_EmailMultiAlternatives = mocker.patch("web.vital_records.tasks.email.EmailMultiAlternatives")
-        mock_email = mock_EmailMultiAlternatives.return_value
-        mock_email.send.return_value = 0
+        mock_email_office = mocker.MagicMock()
+        mock_email_requestor = mocker.MagicMock()
+        mock__create_base_email = mocker.patch(
+            "web.vital_records.tasks.email.EmailTask._create_base_email",
+            side_effect=[
+                mock_email_office,
+                mock_email_requestor,
+            ],
+        )
+
+        # Simulate a success
+        mock_email_office.send.return_value = 1
+        mock_email_requestor.send.return_value = 1
+
         mock__format_record_type = mocker.patch("web.vital_records.tasks.email.EmailTask._format_record_type")
         mock__format_record_type.return_value = request_type_formatted
 
         result = task.handler(request_id, "package")
+
+        mock__format_record_type.assert_called_once()
 
         expected_ctx = {
             "number_of_copies": mock_VitalRecordsRequest.number_of_records,
@@ -68,18 +101,29 @@ class TestEmailTask:
         mock_render.assert_any_call(EMAIL_TXT_TEMPLATE, expected_ctx)
         mock_render.assert_any_call(EMAIL_HTML_TEMPLATE, expected_ctx)
 
-        mock_EmailMultiAlternatives.assert_called_once_with(
-            subject=f"Completed: {request_type_formatted} Record Request",
-            body=mock_render.return_value,
-            to=[settings.VITAL_RECORDS_EMAIL_TO],
+        expected_subject = f"Completed: {request_type_formatted} Record Request"
+        office_call = mocker.call(
+            subject=expected_subject,
+            to_address=[settings.VITAL_RECORDS_EMAIL_TO],
+            text_content="email body",
+            html_content="email body",
         )
+        requestor_call = mocker.call(
+            subject=expected_subject,
+            to_address=[mock_inst.email_address],
+            text_content="email body",
+            html_content="email body",
+        )
+        mock__create_base_email.assert_has_calls([office_call, requestor_call])
 
-        mock_email.attach_alternative.assert_called_once_with(mock_render.return_value, "text/html")
-        mock_email.attach_file.assert_called_once_with("package", "application/pdf")
-        mock_email.send.assert_called_once()
+        mock_email_office.attach_file.assert_called_once_with("package", "application/pdf")
+        mock_email_office.send.assert_called_once()
+
+        mock_email_requestor.attach_file.assert_not_called()
+        mock_email_requestor.send.assert_called_once()
 
         mock_VitalRecordsRequest.complete_send.assert_called_once()
         mock_VitalRecordsRequest.finish.assert_called_once()
         mock_VitalRecordsRequest.save.assert_called_once()
 
-        assert result == 0
+        assert result == (1, 1)

--- a/web/vital_records/templates/vital_records/email.html
+++ b/web/vital_records/templates/vital_records/email.html
@@ -19,7 +19,7 @@
             <strong>Number of copies: {{ number_of_copies }}</strong>
         </p>
         <p>
-            Your application (attached as a PDF to this email) will be sent to CDPH for processing. CDPH typically process applications within 1-2 business days. Once processed, your records will be mailed to you, which typically takes 1-2 weeks from the date completed.
+            Your application will be sent to CDPH for processing. CDPH typically process applications within 1-2 business days. Once processed, your records will be mailed to you, which typically takes 1-2 weeks from the date completed.
         </p>
         <p>You may use your email address {{ email_address }} as your reference number.</p>
         <p>If you have any questions, please contact CDPH by emailing SOEVitalRecords@cdph.ca.gov.</p>

--- a/web/vital_records/templates/vital_records/email.txt
+++ b/web/vital_records/templates/vital_records/email.txt
@@ -6,7 +6,7 @@ Vital Record Type: {{ request_type }}
 
 Number of copies: {{ number_of_copies }}
 
-Your application (attached as a PDF to this email) will be sent to CDPH for processing. CDPH typically process applications within 1-2 business days. Once processed, your records will be mailed to you, which typically takes 1-2 weeks from the date completed.
+Your application will be sent to CDPH for processing. CDPH typically process applications within 1-2 business days. Once processed, your records will be mailed to you, which typically takes 1-2 weeks from the date completed.
 
 You may use your email address {{ email_address }} as your reference number.
 


### PR DESCRIPTION
Closes #406 

This PR implements sending a confirmation email to the vital records requestor. We remove the line `(attached as a PDF to this email)` in the email templates so that the email to CDPH and to the requestor omits this. In addition, a helper `_create_base_email` is created to avoid some code duplication when creating more than one email. The emails to CDPH and to the requestor are created using this helper function. Finally, the return value of `EmailTask.handler` is turned into a tuple (where the first element corresponds to the result of sending the email to CDPH and the second element corresponds to the result of sending the email to the requestor) so that we can determine the result of the task in the admin as shown below:

<img width="2270" height="864" alt="image" src="https://github.com/user-attachments/assets/a0ce2bc9-c94e-49bf-95e0-eac2818a73cd" />

## Reviewing

1. In your `.env` set `AZURE_COMMUNICATION_CONNECTION_STRING` and `DEFAULT_FROM_EMAIL` to blank
2. Run the `Django: Disaster Recovery` debugger and complete a vital records request
3. Run the `Django: Qcluster` debugger to process the request. This will generate 2 files named something like `date-id.log` in the `.inbox` folder.
4. Open each `.log` file and confirm that they do not show the string `(attached as a PDF to this email)` anymore. Also confirm that for the `To:` address, one of the files has the configured CDPH address and the other has the requestor's email address.
5. In the admin, under `Successful tasks`, confirm that the email task was successful and that you see `1, 1` for the result of the task
