### PR TITLE
Fix: clear out values if record request type is changed

### DIFF
--- a/tests/pytest/vital_records/test_forms.py
+++ b/tests/pytest/vital_records/test_forms.py
@@ -17,7 +17,7 @@ class TestTypeForm:
             ("death", "Death record"),
         ]
 
-    def test_save(self):
+    def test_save_type_changed(self):
         # Simulate that a user had started filling out a VitalRecordsRequest instance.
         existing_instance = VitalRecordsRequest.objects.create(
             fire="eaton",
@@ -80,6 +80,68 @@ class TestTypeForm:
         assert existing_instance.zip_code == ""
         assert existing_instance.email_address == ""
         assert existing_instance.phone_number == ""
+
+    def test_save_type_unchanged(self):
+        # Simulate that a user had started filling out a VitalRecordsRequest instance.
+        existing_instance = VitalRecordsRequest.objects.create(
+            fire="eaton",
+            type="birth",
+            relationship="self",
+            legal_attestation="Test User",
+            first_name="First",
+            middle_name="Middle",
+            last_name="Last",
+            county_of_event="Los Angeles",
+            date_of_birth=datetime.datetime(1990, 9, 22, 19, 17, 58, tzinfo=datetime.UTC),
+            date_of_event=datetime.datetime(1990, 9, 22, 19, 17, 58, tzinfo=datetime.UTC),
+            person_1_first_name="First1",
+            person_1_middle_name="Middle1",
+            person_1_last_name="Last1",
+            person_2_first_name="First2",
+            person_2_middle_name="Middle2",
+            person_2_last_name="Last2",
+            order_first_name="Requester",
+            order_last_name="Person",
+            address="123 Main St",
+            address_2="Apt 4A",
+            city="Los Angeles",
+            state="CA",
+            zip_code="90012",
+            email_address="test@example.com",
+            phone_number="3231234567",
+        )
+        existing_instance.save()
+
+        # Then, simulate going back to the form and not changing the type.
+        form = TypeForm(data={"type": "birth"}, instance=existing_instance)
+        form.save()
+
+        assert existing_instance.status == "initialized"
+        assert existing_instance.fire == "eaton"
+        assert existing_instance.type == "birth"
+        assert existing_instance.relationship == "self"
+        assert existing_instance.legal_attestation == "Test User"
+        assert existing_instance.first_name == "First"
+        assert existing_instance.middle_name == "Middle"
+        assert existing_instance.last_name == "Last"
+        assert existing_instance.county_of_event == "Los Angeles"
+        assert existing_instance.date_of_birth == datetime.datetime(1990, 9, 22, 19, 17, 58, tzinfo=datetime.UTC)
+        assert existing_instance.date_of_event == datetime.datetime(1990, 9, 22, 19, 17, 58, tzinfo=datetime.UTC)
+        assert existing_instance.person_1_first_name == "First1"
+        assert existing_instance.person_1_middle_name == "Middle1"
+        assert existing_instance.person_1_last_name == "Last1"
+        assert existing_instance.person_2_first_name == "First2"
+        assert existing_instance.person_2_middle_name == "Middle2"
+        assert existing_instance.person_2_last_name == "Last2"
+        assert existing_instance.order_first_name == "Requester"
+        assert existing_instance.order_last_name == "Person"
+        assert existing_instance.address == "123 Main St"
+        assert existing_instance.address_2 == "Apt 4A"
+        assert existing_instance.city == "Los Angeles"
+        assert existing_instance.state == "CA"
+        assert existing_instance.zip_code == "90012"
+        assert existing_instance.email_address == "test@example.com"
+        assert existing_instance.phone_number == "3231234567"
 
 
 @pytest.mark.parametrize(

--- a/web/vital_records/forms/common.py
+++ b/web/vital_records/forms/common.py
@@ -181,14 +181,15 @@ class TypeForm(DisableFieldsMixin, forms.ModelForm):
         When saving the type, we need to reset all the fields that are filled out by later forms in case
         we are saving the type because the user came back to the type form.
         """
-        # Create a new instance so we can copy the values to our existing instance.
-        # We cannot simply save the new instance as the existing one because the Django ORM will raise an IntegrityError.
-        new_instance = VitalRecordsRequest()
+        if "type" in self.changed_data:
+            # Create a new instance so we can copy the values to our existing instance.
+            # We cannot simply save the new instance as the existing one because the Django ORM will raise an IntegrityError.
+            new_instance = VitalRecordsRequest()
 
-        for f in self.instance._meta.fields:
-            if f.name not in ["id", "type", "fire", "status"]:
-                field_value = getattr(new_instance, f.name)
-                setattr(self.instance, f.name, field_value)
+            for f in self.instance._meta.fields:
+                if f.name not in ["id", "type", "fire", "status"]:
+                    field_value = getattr(new_instance, f.name)
+                    setattr(self.instance, f.name, field_value)
 
         return super().save(commit=commit)
 


### PR DESCRIPTION
If the user has started filling out the flow for a certain record type and then goes back and changes the type, it is not desired for the previous values to show up in the form fields.

For example, say a user started a request for a death record and filled out "Parent's name" and "Spouse's name". If they go back and change their request to be for a marriage record, we wouldn't want those values to show up as "First person" and "Second person" on the marriage name form.

If however the user simply went back to the Type page and did not actually change the record request type, the form data filled out so far should stay intact.