### PR TITLE
Fix: ensure `started_at` is not null

### DIFF
--- a/web/vital_records/forms/common.py
+++ b/web/vital_records/forms/common.py
@@ -187,7 +187,7 @@ class TypeForm(DisableFieldsMixin, forms.ModelForm):
             new_instance = VitalRecordsRequest()
 
             for f in self.instance._meta.fields:
-                if f.name not in ["id", "type", "fire", "status"]:
+                if f.name not in ["id", "type", "fire", "status", "started_at"]:
                     field_value = getattr(new_instance, f.name)
                     setattr(self.instance, f.name, field_value)
 


### PR DESCRIPTION
Follow-up to #416 

After deploying `2025.09.2-rc1` to `test` we noticed this error:

```
Failed '<bound method PackageTask.handler of <web.vital_records.tasks.package.PackageTask object at 0x7171b4f10ec0>>' (package) - 'NoneType' object has no attribute 'astimezone' : Traceback (most recent call last):
File "/home/cdt/.local/lib/python3.12/site-packages/django_q/worker.py", line 103, in worker
res = f(*task["args"], **task["kwargs"])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/cdt/.local/lib/python3.12/site-packages/web/vital_records/tasks/package.py", line 286, in handler
sworn_statement = SwornStatement.create_death_sworn_statement(request)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/cdt/.local/lib/python3.12/site-packages/web/vital_records/tasks/package.py", line 254, in create_death_sworn_statement
return SwornStatement.create_sworn_statement(request, registrant_fields)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/cdt/.local/lib/python3.12/site-packages/web/vital_records/tasks/package.py", line 230, in create_sworn_statement
auth_time = request.started_at.astimezone(timezone.get_default_timezone()).strftime("%Y-%m-%d %H:%M:%S")
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'astimezone'
```

Turns out that `started_at` is set in `StartView` and is not re-set later in the flow, so we shouldn't  clear out `started_at` if the user changes the type of request. Note that the clearing out logic is run even the first time a user is going through the flow because `self.changed_data` contains `type` in https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/forms/common.py#L184.

This PR ensures that if `type` is changed in `TypeView`, the previously set `started_at` value is preserved and not cleared out.

## Reviewing

1. In your `.env` set `AZURE_COMMUNICATION_CONNECTION_STRING` and `DEFAULT_FROM_EMAIL` to blank
2. Run the `Django: Disaster Recovery` debugger and complete a vital records request
3. Run the `Django: Qcluster` debugger to process the request. Ensure that the PDF application and 2 files named something like `date-id.log` are created in the `.inbox` folder.
4. Repeat steps 2 and 3, but for step 2, midway through the flow, go back and change the request type. Complete the new request and verify step 3.
