### PR TITLE
Chore: copy updates

### DIFF
--- a/web/vital_records/templates/vital_records/request/statement.html
+++ b/web/vital_records/templates/vital_records/request/statement.html
@@ -6,7 +6,7 @@
     <div class="row">
         <div class="col-lg-10">
             <p class="m-t p-b m-b-sm">
-                To get an authorized copy, you must be the person named on the record or someone legally allowed to request it — like a parent, guardian, child, sibling, grandparent or spouse.
+                To get an authorized copy, you must be the individual legally authorized to make this request — like a parent, guardian, child, sibling, grandparent or spouse.
             </p>
         </div>
     </div>

--- a/web/vital_records/views/death.py
+++ b/web/vital_records/views/death.py
@@ -36,7 +36,7 @@ class CountyView(ValidateTypeMixin, common.CountyView):
         context = super().get_context_data(**kwargs)
         context["form_question"] = "What was the county of death?"
         context["form_hint"] = (
-            "We can only issue death records for deaths that occurred in California. If the death took place in a "
+            "We can only issue death records that occurred in California. If the death took place in a "
             "different state, please contact the Vital Records office in the state the death occurred in to request "
             "a new record."
         )


### PR DESCRIPTION
Closes #421 

This PR makes 2 copy updates per CDPH's feedback from [`2025.09.2-rc2`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/releases/tag/2025.09.2-rc2) (death flow review).

## Screenshots

### Copy update 1
Before
<img width="1936" height="982" alt="image" src="https://github.com/user-attachments/assets/a84a6b97-836f-4387-986f-43b4c7745cf6" />

After
<img width="1828" height="966" alt="image" src="https://github.com/user-attachments/assets/6139d3ba-cce5-44c9-b635-4d0b71f54b4e" />


### Copy update 2
Before
<img width="2294" height="1058" alt="image" src="https://github.com/user-attachments/assets/e039c60a-d8d5-439a-81d5-34ba51a7bc3f" />

After
<img width="2324" height="1062" alt="image" src="https://github.com/user-attachments/assets/65825163-9832-43f4-8314-0aa926c1580b" />

