### PR TITLE
Fix: typo in aria-describedby prop in order.html

### DIFF
--- a/web/vital_records/templates/vital_records/request/order.html
+++ b/web/vital_records/templates/vital_records/request/order.html
@@ -3,7 +3,7 @@
 {% load form_helpers %}
 {% block flow-container %}
     <form method="post" class="form">
-        <fieldset role="group" aria-describedby="orders-hint">
+        <fieldset role="group">
             <legend>
                 <h2 class="m-b-md p-b">Order information</h2>
             </legend>


### PR DESCRIPTION
Closes #440

Small fix to ~use the context variable `form_hint_name` instead of a hardcoded ID.~ remove the `aria-describedby` attribute, see discussion in the comments.

Minor clarification since I was a bit confused initially if `aria-describedby` was even needed: the [view](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/views/common.py#L171) using this template does not set `form_hint_name`, but we still want to convey this to the `aria-describedby` property and not point it to a non-existing id. This is similar to how the [death flow's parent view](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/views/death.py#L78) works. Whenever the title of the form is self explanatory, there is no need to set the `form_hint` and `form_hint_name` context variables. And it's fine for `aria-describedby` to be a blank string when the template gets rendered.
