### PR TITLE
Chore: remove redundant ARIA role attributes

### DIFF
--- a/web/vital_records/templates/vital_records/request/form.html
+++ b/web/vital_records/templates/vital_records/request/form.html
@@ -1,7 +1,7 @@
 {% extends "vital_records/flow_base.html" %}
 {% block flow-container %}
     <form method="post" class="form">
-        <fieldset role="group" aria-describedby="{{ form_hint_name }}">
+        <fieldset aria-describedby="{{ form_hint_name }}">
             <legend>
                 <h2>{{ form_question }}</h2>
             </legend>

--- a/web/vital_records/templates/vital_records/request/order.html
+++ b/web/vital_records/templates/vital_records/request/order.html
@@ -3,7 +3,7 @@
 {% load form_helpers %}
 {% block flow-container %}
     <form method="post" class="form">
-        <fieldset role="group">
+        <fieldset>
             <legend>
                 <h2 class="m-b-md p-b">Order information</h2>
             </legend>


### PR DESCRIPTION
Closes #441

Removes the ARIA `role` attribute since it is [implicitly set to `group`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset#technical_summary).
