### PR TITLE
Feat: add visually hidden text to indicate external link

### DIFF
--- a/web/vital_records/templates/vital_records/request/order.html
+++ b/web/vital_records/templates/vital_records/request/order.html
@@ -12,7 +12,7 @@
             <h3>Where should we mail your order?</h3>
             <p class="p-b-md m-b-0">
                 Please enter an address in the United States. If you would like to request your document to an international address, please exit this process and <strong><a href="https://www.ca.gov/lafires/vital-records/#Records-from-California"
-   target="_blank">complete your request via Docusign</a></strong>.
+   target="_blank">complete your request via Docusign<span class="visually-hidden"> (opens in a new window)</span></a></strong>.
             </p>
             {% include "vital_records/_two_column_form.html" with form=form fields=name_fields %}
             <div class="row">


### PR DESCRIPTION
Closes #439 

This PR adds some text to the Docusign link on the order form page so that users of assistive tech like screenreaders are also informed that the link will open in a new window. Previously, the only thing communicating that was an icon (the `.external-link-icon::after` pseudo-element) which is not read by screenreaders.

| Screenshot of external link icon |
| --- |
|<img width="1182" height="434" alt="Screenshot from 2025-10-27 14-13-49" src="https://github.com/user-attachments/assets/8c28ce44-de83-45db-bb2d-dff6c0d13cee" /> |


The general concensus on how to implement screen-reader only text is to hide it using CSS. There are various techniques documented online, but with conflicting recommendations:

- [WebAIM](https://webaim.org/techniques/css/invisiblecontent/) in 2020 recommended either "Absolutely positioning content off-screen" using `left: -10000px` or using "CSS clip" with a negative margin
- A site called ["sitelint"](https://www.sitelint.com/blog/hiding-a-text-but-making-it-accessible-to-a-screen-reader#is_there_a_way_to_test_whether_the_hidden_text_is_actually_being_read_by_screen_readers_after_applying_the_visually-hidden_class) in 2023 recommended against the technique of shoving content off-screen and for the `clip` + negative margin implementation
- The StackOverflow answer at https://stackoverflow.com/a/62109988 notes an issue with using negative margin and contains a detailed explanation of an implementation that avoids it (2020)
  - An interesting comment from the discussion on that answer: 
  > There are many variations of this class across the web, and information is scattered (this pull request, that Medium blog post, etc.). It is not easy to find why some alterations were made, nor to know what you should use ultimately.
- Bootstrap has included a utility class called `sr-only` at least [since Bootstrap 3](https://stackoverflow.com/questions/19758598/what-is-sr-only-in-bootstrap-3) - it uses the `clip` + negative margin technique

In Bootstrap 5.3, which is [what we're using](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/36c7f3a714b8f033ba403a0c635ff9d9d1d427e9/web/settings.py#L342), the class is now called [`visually-hidden`](https://getbootstrap.com/docs/5.3/getting-started/accessibility/#visually-hidden-content) and seems to still use the same technique. This PR makes use of that class with awareness that we're trusting Bootstrap's choice of implementation.

## Screenshots

<img width="1920" height="1152" alt="Screenshot from 2025-10-27 14-59-20" src="https://github.com/user-attachments/assets/aa28d5d7-bc26-4e2c-8977-a3c614fe4e5c" />

<img width="1914" height="1110" alt="image" src="https://github.com/user-attachments/assets/db210c4e-5096-4848-9fd0-3d2199eaa3b9" />
