### PR TITLE
Fix: add missing Key Vault access policy for functions app

### DIFF
--- a/terraform/modules/application/outputs.tf
+++ b/terraform/modules/application/outputs.tf
@@ -17,8 +17,9 @@ output "default_domains" {
 output "identity_object_ids" {
   description = "A map of the Object IDs for the application managed identities."
   value = {
-    web    = azurerm_user_assigned_identity.web_app_identity.principal_id
-    worker = azurerm_user_assigned_identity.worker_app_identity.principal_id
+    web       = azurerm_user_assigned_identity.web_app_identity.principal_id
+    worker    = azurerm_user_assigned_identity.worker_app_identity.principal_id
+    functions = azurerm_user_assigned_identity.functions_app_identity.principal_id
   }
 }
 

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -38,6 +38,15 @@ resource "azurerm_key_vault_access_policy" "container_app_worker_access" {
   secret_permissions = local.key_vault_policy_secret_permissions
 }
 
+# Key Vault access policy for the functions app
+resource "azurerm_key_vault_access_policy" "container_app_functions_access" {
+  key_vault_id = module.key_vault.key_vault_id
+  tenant_id    = local.tenant_id
+  object_id    = module.application.identity_object_ids.functions
+
+  secret_permissions = local.key_vault_policy_secret_permissions
+}
+
 # These rules are for the 'public' NSG created in the network module.
 # They allow outbound traffic to private IP addresses of the database, key vault, and storage account.
 resource "azurerm_network_security_rule" "public_to_db" {


### PR DESCRIPTION
Follow-up to #428 

The `terraform apply`for #428 failed because it was missing the Key Vault access policy for the functions app. This PR fixes that oversight by adding the missing policy.