### PR TITLE
Fix: typo in Azure Function query string key

### DIFF
--- a/azure_functions/function_app.py
+++ b/azure_functions/function_app.py
@@ -84,12 +84,12 @@ def alert_to_slack(req: func.HttpRequest) -> func.HttpResponse:
     """
     logging.info("alert_to_slack processed a request.")
 
-    provided_code = req.params.get("CODE")
+    provided_code = req.params.get("code")
     if not provided_code:
-        return func.HttpResponse("Missing CODE authentication.", status_code=401)
+        return func.HttpResponse("Missing code authentication.", status_code=401)
     if provided_code != FUNCTION_KEY:
-        logging.warning("Invalid CODE provided.")
-        return func.HttpResponse("Unauthorized: invalid CODE.", status_code=403)
+        logging.warning("Invalid code provided.")
+        return func.HttpResponse("Unauthorized: invalid code.", status_code=403)
 
     try:
         alert_data = req.get_json()


### PR DESCRIPTION
Follow-up to #428 

By manually testing the Application Insights action group, noticed a typo in the Azure function. This PR fixes the typo in the query string's key name. Instead of "CODE" it should have been "code" to match the [URI in the Azure Monitor action group](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/terraform/modules/monitoring/main.tf#L38).
