### PR TITLE
Fix: add exception handling for Log Search alerts

### DIFF
--- a/azure_functions/function_app.py
+++ b/azure_functions/function_app.py
@@ -69,7 +69,7 @@ def format_for_slack(data: dict) -> str:
                             if key == "rawStack" and isinstance(v, str):
                                 # Format traceback as code block in Slack
                                 stack = textwrap.dedent(value).strip()
-                                formatted_lines.append(f"*{key}:*\n```{stack}```")
+                                formatted_lines.append(f"*{key}:*\n```\n{stack}\n```")
                 else:
                     formatted_lines.append(f"*details:* {details}")
             except json.JSONDecodeError:


### PR DESCRIPTION
Follow-up to #428

The Azure function is able to [receive messages from the action group](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/terraform/modules/monitoring/main.tf#L36) as shown in our test Slack channel and in the logs of the Azure Function Container App. However, in some cases, the `details` field in the results of the Log Search alert (fetched from the Azure Monitor Log Analytics API) may not be valid JSON and this triggers an exception in the Azure function. This PR adds an exception handler for this situation.

This PR also adds line breaks for the `rawStack` field to ensure the text renders as code in Slack.
