### PR TITLE
Refactor: replace PAT login with Azure/login using service principal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,9 +109,12 @@ jobs:
       - name: Install/Update Azure DevOps Extension
         run: az extension add --upgrade -y --name azure-devops
 
-      - name: Login to Azure DevOps
-        run: |
-          echo ${{ secrets.ADO_PAT }} | az devops login --organization ${{ secrets.ADO_ORG_URL }}
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Trigger Azure pipeline run
         id: trigger_pipeline


### PR DESCRIPTION
Part of #178 

This PR contains the main change we want to make for #178, which namely is to use a service principal to authenticate instead of a PAT. This PR switches out the raw bash step that calls `az devops login` with usage of the [`azure/login`](https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended) action

There are some other clean-ups we'd like to do (e.g. try using the `azure/cli` action for the ["Trigger Azure pipeline run"](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/bc04d3d1191504b54a5f51858e4f89c61c9d4df6/.github/workflows/deploy.yml#L116) step, try removing the step of [installing the `az devops` extension](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/bc04d3d1191504b54a5f51858e4f89c61c9d4df6/.github/workflows/deploy.yml#L109)), but let's do these one at time so that it's easier to troubleshoot if needed.

## Post-merge (if this works)
- [ ] Delete this repo's `ADO_PAT` GitHub secret