### PR TITLE
Feat: add Azure Monitor workspace

### DIFF
--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -10,6 +10,7 @@ locals {
   key_vault_secret_uri_prefix       = "https://${local.key_vault_name}.vault.azure.net/secrets"
   location                          = data.azurerm_resource_group.main.location
   log_analytics_workspace_name      = "CDT-OET-PUB-DDRC-${local.env_letter}-001"
+  monitor_workspace_name            = "AMW-CDT-PUB-VIP-DDRC-${local.env_letter}-001"
   nat_gateway_name                  = lower("nat-cdt-pub-vip-ddrc-${local.env_letter}-001")
   nsg_prefix                        = "NSG-CDT-PUB-VIP-DDRC-${local.env_letter}"
   private_endpoint_prefix           = lower("pe-cdt-pub-vip-ddrc-${local.env_letter}")
@@ -71,6 +72,7 @@ module "monitoring" {
   resource_group_name           = local.resource_group_name
   location                      = local.location
   log_analytics_workspace_name  = local.log_analytics_workspace_name
+  monitor_workspace_name        = local.monitor_workspace_name
   application_insights_name     = local.application_insights_name
   action_group_name             = "Slack channel email"
   action_group_short_name       = "slack-notify"

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -10,6 +10,16 @@ resource "azurerm_log_analytics_workspace" "main" {
   }
 }
 
+resource "azurerm_monitor_workspace" "main" {
+  name                = var.monitor_workspace_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
 resource "azurerm_application_insights" "main" {
   name                = var.application_insights_name
   application_type    = "web"

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -15,6 +15,11 @@ variable "log_analytics_workspace_name" {
   type        = string
 }
 
+variable "monitor_workspace_name" {
+  description = "The name for the Azure Monitor Workspace."
+  type        = string
+}
+
 variable "application_insights_name" {
   description = "The name for the Application Insights instance."
   type        = string


### PR DESCRIPTION
Closes #430

This PR adds an Azure Monitor workspace that will enable us to run an investigation on alerts generated by Application Insights.
