### PR TITLE
Refactor(CI): use azure/cli action to run `az devops` commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,49 +118,55 @@ jobs:
 
       - name: Trigger Azure pipeline run
         id: trigger_pipeline
-        run: |
-          RUN_ID=$(az pipelines run \
-            --id "${{ secrets.ADO_PIPELINE_ID }}" \
-            --org "${{ secrets.ADO_ORG_URL }}" \
-            --project "${{ secrets.ADO_PROJECT }}" \
-            --branch "${{ github.ref }}" \
-            --commit-id ${{ github.sha }} \
-            --query "id" -o tsv)
-          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
-
-      - name: Wait for Azure pipeline run to complete
-        run: |
-          echo "Waiting for Azure DevOps Pipeline run to complete..."
-          while true; do
-            PIPELINE_STATUS=$(az pipelines runs show \
-              --id ${{ steps.trigger_pipeline.outputs.run_id }} \
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            RUN_ID=$(az pipelines run \
+              --id "${{ secrets.ADO_PIPELINE_ID }}" \
               --org "${{ secrets.ADO_ORG_URL }}" \
               --project "${{ secrets.ADO_PROJECT }}" \
-              --query "status" -o tsv)
+              --branch "${{ github.ref }}" \
+              --commit-id ${{ github.sha }} \
+              --query "id" -o tsv)
+            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
 
-            echo "Current pipeline status: $PIPELINE_STATUS"
-
-            if [[ "$PIPELINE_STATUS" == "completed" ]]; then
-              PIPELINE_RESULT=$(az pipelines runs show \
+      - name: Wait for Azure pipeline run to complete
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            echo "Waiting for Azure DevOps Pipeline run to complete..."
+            while true; do
+              PIPELINE_STATUS=$(az pipelines runs show \
                 --id ${{ steps.trigger_pipeline.outputs.run_id }} \
                 --org "${{ secrets.ADO_ORG_URL }}" \
                 --project "${{ secrets.ADO_PROJECT }}" \
-                --query "result" -o tsv)
+                --query "status" -o tsv)
 
-              echo "Pipeline completed with result: $PIPELINE_RESULT"
-              if [[ "$PIPELINE_RESULT" == "succeeded" ]]; then
-                exit 0
+              echo "Current pipeline status: $PIPELINE_STATUS"
+
+              if [[ "$PIPELINE_STATUS" == "completed" ]]; then
+                PIPELINE_RESULT=$(az pipelines runs show \
+                  --id ${{ steps.trigger_pipeline.outputs.run_id }} \
+                  --org "${{ secrets.ADO_ORG_URL }}" \
+                  --project "${{ secrets.ADO_PROJECT }}" \
+                  --query "result" -o tsv)
+
+                echo "Pipeline completed with result: $PIPELINE_RESULT"
+                if [[ "$PIPELINE_RESULT" == "succeeded" ]]; then
+                  exit 0
+                else
+                  echo "Azure DevOps Pipeline failed with result: $PIPELINE_RESULT"
+                  exit 1
+                fi
+              elif [[ "$PIPELINE_STATUS" == "cancelling" || "$PIPELINE_STATUS" == "notStarted" || "$PIPELINE_STATUS" == "inProgress" ]]; then
+                sleep 10
               else
-                echo "Azure DevOps Pipeline failed with result: $PIPELINE_RESULT"
+                echo "Azure DevOps Pipeline finished with unexpected status: $PIPELINE_STATUS"
                 exit 1
               fi
-            elif [[ "$PIPELINE_STATUS" == "cancelling" || "$PIPELINE_STATUS" == "notStarted" || "$PIPELINE_STATUS" == "inProgress" ]]; then
-              sleep 10
-            else
-              echo "Azure DevOps Pipeline finished with unexpected status: $PIPELINE_STATUS"
-              exit 1
-            fi
-          done
+            done
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Part of #178 

Follow-up to #459 

This PR updates the "Trigger Azure pipeline run" step to use the [`azure/cli` GitHub Action ](https://github.com/marketplace/actions/azure-cli-action)rather than just running it in a standalone bash session. Hopefully this makes it so the authentication done by the "Azure login" step using the `azure/login` GH Action is used for the `az devops` commands.

## Post-merge

We learned that the [GitHub Ubuntu runner image](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cli-tools) includes `Azure CLI (azure-devops)`.

If this works, we should open a follow-up PR to try removing the "Install/Update Azure DevOps Extension" step and see if things still work. It seems like we shouldn't need it, but for ease of troubleshooting if this doesn't work, I want to keep this PR scoped to one change only.