### PR TITLE
Chore: try calling `az login` before calling `az devops` commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
+            az login
             RUN_ID=$(az pipelines run \
               --id "${{ secrets.ADO_PIPELINE_ID }}" \
               --org "${{ secrets.ADO_ORG_URL }}" \
@@ -136,6 +137,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
+            az login
             echo "Waiting for Azure DevOps Pipeline run to complete..."
             while true; do
               PIPELINE_STATUS=$(az pipelines runs show \


### PR DESCRIPTION
Part of #178 

The docs for `azure/login` and `azure/cli` sure seem to imply that the two should be able to share the same login context. 
For example, https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-openid-connect#the-workflow-sample-to-only-run-azure-cli.

I wonder if both steps _are_ necessary, but the second step needs to do something to actually use the login context.

Going off some output I got when messing around with calling `az pipelines list` locally:
```
The Azure DevOps Extension for the Azure CLI does not support Azure DevOps Server.
Before you can run Azure DevOps commands, you need to run the login command(az login if using AAD/MSA identity else az devops login if using PAT token) to setup credentials.  Please see https://aka.ms/azure-devops-cli-auth for more information.
```

>  ... you need to run the login command(az login if using AAD/MSA identity

Maybe we can just run `az login`?