### PR TITLE
Chore: access token to use Azure DevOps CLI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az login
+            az account get-access-token --resource ${{ secrets.ADO_ORG_URL }}
             RUN_ID=$(az pipelines run \
               --id "${{ secrets.ADO_PIPELINE_ID }}" \
               --org "${{ secrets.ADO_ORG_URL }}" \
@@ -137,7 +137,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az login
+            az account get-access-token --resource ${{ secrets.ADO_ORG_URL }}
             echo "Waiting for Azure DevOps Pipeline run to complete..."
             while true; do
               PIPELINE_STATUS=$(az pipelines runs show \


### PR DESCRIPTION
Part of #178 

Follow-up to #462 

We're gonna try leaving the `azure/login` step so that it logs in with the federated credential and then call `az account get-access-token...` to ask for access to Azure DevOps.

https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/pull/462#issuecomment-3470379852