### PR TITLE
Chore: use URL from Microsoft documentation instead of our ADO URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az account get-access-token --resource ${{ secrets.ADO_ORG_URL }}
+            az account get-access-token --resource https://app.vssps.visualstudio.com/
             RUN_ID=$(az pipelines run \
               --id "${{ secrets.ADO_PIPELINE_ID }}" \
               --org "${{ secrets.ADO_ORG_URL }}" \
@@ -137,7 +137,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az account get-access-token --resource ${{ secrets.ADO_ORG_URL }}
+            az account get-access-token --resource https://app.vssps.visualstudio.com/
             echo "Waiting for Azure DevOps Pipeline run to complete..."
             while true; do
               PIPELINE_STATUS=$(az pipelines runs show \


### PR DESCRIPTION
Part of #178 

Follow-up to #459, #462, #463, #464 

The deploy pipeline still has yet to successfully call `az devops` / `az pipelines` commands using the service principal's federated-credential-based authentication.

We thought we had pinpointed the issue with seeing [this bit of documentation](https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/service-principal-managed-identity?view=azure-devops#tf401444-sign-in-required-error):

> ### TF401444: Sign-in required error
> 
> **Solution**: Ensure that the service principal is added properly to the organization with required permissions. This error indicates that the identity isn't recognized in the organization.

We've been seeing that exact error since the very first PR for all this (#459), so it really seems like the root issue. But even after DevSecOps made sure that the service principal has been added to the org, we still see the same error.

We're gonna try a few more tweaks to the workflow code just to see what happens.

First one is to use the URL mentioned in this documentation:

https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/service-principal-managed-identity?view=azure-devops#azure-cli-for-ad-hoc-operations

instead of our ADO URL.