### PR TITLE
Chore: use ADO environment variable to authenticate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,8 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798
+            ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+            export AZURE_DEVOPS_EXT_PAT=$ADO_TOKEN
             RUN_ID=$(az pipelines run \
               --id "${{ secrets.ADO_PIPELINE_ID }}" \
               --org "${{ secrets.ADO_ORG_URL }}" \
@@ -137,7 +138,8 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798
+            ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+            export AZURE_DEVOPS_EXT_PAT=$ADO_TOKEN
             echo "Waiting for Azure DevOps Pipeline run to complete..."
             while true; do
               PIPELINE_STATUS=$(az pipelines runs show \


### PR DESCRIPTION
Follow up to #468 

Trying the approach laid out in https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/pull/468#issuecomment-3474424750 where we try to use the `AZURE_DEVOPS_EXT_PAT` environment variable to authenticate. 

Maybe a followup, if this PR doesn't work, is to try

- `--resource ${{ secrets.ADO_ORG_URL }}`
- `--resource https://app.vssps.visualstudio.com/`

in the `az account get-access-token` command.