### PR TITLE
Refactor(CI): use service principal client secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,7 +110,16 @@ jobs:
         id: trigger_pipeline
         run: |
           az login --service-principal --username ${{ secrets.AZURE_CLIENT_ID }} --password ${{ secrets.AZURE_CLIENT_SECRET }} --tenant ${{ secrets.AZURE_TENANT_ID }}
-          az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798
+
+          AZURE_DEVOPS_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken --output tsv)
+
+          if [ -z "$AZURE_DEVOPS_TOKEN" ]; then
+            echo "Failed to get Azure DevOps token"
+            exit 1
+          fi
+
+          export AZURE_DEVOPS_EXT_PAT=$AZURE_DEVOPS_TOKEN
+
           RUN_ID=$(az pipelines run \
             --id "${{ secrets.ADO_PIPELINE_ID }}" \
             --org "${{ secrets.ADO_ORG_URL }}" \
@@ -123,7 +132,16 @@ jobs:
       - name: Wait for Azure pipeline run to complete
         run: |
           az login --service-principal --username ${{ secrets.AZURE_CLIENT_ID }} --password ${{ secrets.AZURE_CLIENT_SECRET }} --tenant ${{ secrets.AZURE_TENANT_ID }}
-          az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798
+
+          AZURE_DEVOPS_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken --output tsv)
+
+          if [ -z "$AZURE_DEVOPS_TOKEN" ]; then
+            echo "Failed to get Azure DevOps token"
+            exit 1
+          fi
+
+          export AZURE_DEVOPS_EXT_PAT=$AZURE_DEVOPS_TOKEN
+
           echo "Waiting for Azure DevOps Pipeline run to complete..."
           while true; do
             PIPELINE_STATUS=$(az pipelines runs show \


### PR DESCRIPTION
Part of #178 

Follow-up to #468 

This PR has us log in using `az login` within those run steps using a service-principal client-secret approach, i.e.:
```
az login --service-principal --username {client-id} --password {client-secret} --tenant {tenant-id}
az account get-access-token --resource https://app.vssps.visualstudio.com/
```
_source: https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/service-principal-managed-identity?view=azure-devops#azure-cli-for-ad-hoc-operations_

I created a GitHub secret in this repo called `AZURE_CLIENT_SECRET` which needs to be updated to contain a client secret generated for the service principal.

_edit_: client secret has been added by DevSecOps
