### PR TITLE
Chore(CI): try running Azure devops steps with bash-session run step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,59 +118,53 @@ jobs:
 
       - name: Trigger Azure pipeline run
         id: trigger_pipeline
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
-            export AZURE_DEVOPS_EXT_PAT=$ADO_TOKEN
-            RUN_ID=$(az pipelines run \
-              --id "${{ secrets.ADO_PIPELINE_ID }}" \
-              --org "${{ secrets.ADO_ORG_URL }}" \
-              --project "${{ secrets.ADO_PROJECT }}" \
-              --branch "${{ github.ref }}" \
-              --commit-id ${{ github.sha }} \
-              --query "id" -o tsv)
-            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+        run: |
+          ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+          export AZURE_DEVOPS_EXT_PAT=$ADO_TOKEN
+          RUN_ID=$(az pipelines run \
+            --id "${{ secrets.ADO_PIPELINE_ID }}" \
+            --org "${{ secrets.ADO_ORG_URL }}" \
+            --project "${{ secrets.ADO_PROJECT }}" \
+            --branch "${{ github.ref }}" \
+            --commit-id ${{ github.sha }} \
+            --query "id" -o tsv)
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Wait for Azure pipeline run to complete
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
-            export AZURE_DEVOPS_EXT_PAT=$ADO_TOKEN
-            echo "Waiting for Azure DevOps Pipeline run to complete..."
-            while true; do
-              PIPELINE_STATUS=$(az pipelines runs show \
+        run: |
+          ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+          export AZURE_DEVOPS_EXT_PAT=$ADO_TOKEN
+          echo "Waiting for Azure DevOps Pipeline run to complete..."
+          while true; do
+            PIPELINE_STATUS=$(az pipelines runs show \
+              --id ${{ steps.trigger_pipeline.outputs.run_id }} \
+              --org "${{ secrets.ADO_ORG_URL }}" \
+              --project "${{ secrets.ADO_PROJECT }}" \
+              --query "status" -o tsv)
+
+            echo "Current pipeline status: $PIPELINE_STATUS"
+
+            if [[ "$PIPELINE_STATUS" == "completed" ]]; then
+              PIPELINE_RESULT=$(az pipelines runs show \
                 --id ${{ steps.trigger_pipeline.outputs.run_id }} \
                 --org "${{ secrets.ADO_ORG_URL }}" \
                 --project "${{ secrets.ADO_PROJECT }}" \
-                --query "status" -o tsv)
+                --query "result" -o tsv)
 
-              echo "Current pipeline status: $PIPELINE_STATUS"
-
-              if [[ "$PIPELINE_STATUS" == "completed" ]]; then
-                PIPELINE_RESULT=$(az pipelines runs show \
-                  --id ${{ steps.trigger_pipeline.outputs.run_id }} \
-                  --org "${{ secrets.ADO_ORG_URL }}" \
-                  --project "${{ secrets.ADO_PROJECT }}" \
-                  --query "result" -o tsv)
-
-                echo "Pipeline completed with result: $PIPELINE_RESULT"
-                if [[ "$PIPELINE_RESULT" == "succeeded" ]]; then
-                  exit 0
-                else
-                  echo "Azure DevOps Pipeline failed with result: $PIPELINE_RESULT"
-                  exit 1
-                fi
-              elif [[ "$PIPELINE_STATUS" == "cancelling" || "$PIPELINE_STATUS" == "notStarted" || "$PIPELINE_STATUS" == "inProgress" ]]; then
-                sleep 10
+              echo "Pipeline completed with result: $PIPELINE_RESULT"
+              if [[ "$PIPELINE_RESULT" == "succeeded" ]]; then
+                exit 0
               else
-                echo "Azure DevOps Pipeline finished with unexpected status: $PIPELINE_STATUS"
+                echo "Azure DevOps Pipeline failed with result: $PIPELINE_RESULT"
                 exit 1
               fi
-            done
+            elif [[ "$PIPELINE_STATUS" == "cancelling" || "$PIPELINE_STATUS" == "notStarted" || "$PIPELINE_STATUS" == "inProgress" ]]; then
+              sleep 10
+            else
+              echo "Azure DevOps Pipeline finished with unexpected status: $PIPELINE_STATUS"
+              exit 1
+            fi
+          done
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Part of #178 

This is similar to the very first run of `deploy.yml` after #459 was merged in. The difference is it contains syntax to set the `AZURE_DEVOPS_EXT_PAT` environment variable.