### PR TITLE
Fix: mock open() so files are not written to disk

### DIFF
--- a/tests/web/vital_records/tasks/test_package.py
+++ b/tests/web/vital_records/tasks/test_package.py
@@ -293,6 +293,10 @@ class TestPackageTask:
     def task(self, request_id) -> PackageTask:
         return PackageTask(request_id)
 
+    @pytest.fixture(autouse=True)
+    def mock_open(self, mocker):
+        mocker.patch("web.vital_records.tasks.package.open")
+
     def test_task(self, request_id, task):
         assert task.group == "vital-records"
         assert task.name == "package"


### PR DESCRIPTION
Closes #374 

This was a simple fix to mock the stdlib `open()` function that opens a file on disk for writing, during all tests of the [`PackageTask`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/web/vital_records/tasks/package.py#L267). 

No other changes were required and all tests still pass

## How to review this PR

1. Check out this branch locally
2. Run all the tests in the VS Code test runner and/or on the CLI
3. See all tests pass
4. See _no_ PDF files generated in your local `./inbox`