### PR TITLE
Refactor: make Application Insights alerts to Slack more robust

### DIFF
--- a/azure_functions/function_app.py
+++ b/azure_functions/function_app.py
@@ -126,7 +126,7 @@ def format_search_results(data: dict) -> str:
             formatted_lines.append(f"*Details*:\n```\n{stack}\n```")
         else:
             formatted_lines.append(format_item("Details", details))
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         formatted_lines.append(format_item("Details", details))
 
     formatted_message = "\n".join(formatted_lines) + "\n"

--- a/tests/azure_functions/test_function_app.py
+++ b/tests/azure_functions/test_function_app.py
@@ -268,6 +268,16 @@ def test_select_search_results_no_data():
         ({}, "_No additional details found._\n"),
         ({"outerMessage": "Error msg"}, "*Message*: Error msg\n*Details*: \n"),
         ({"details": "This is just a string."}, "*Message*: \n*Details*: This is just a string.\n"),
+        (
+            {
+                "details": (
+                    '[{"message": "Error", "severityLevel": "Error"}, '
+                    '{"message": "Error", "parsedStack": "Traceback...", "severityLevel": "Error"}]'
+                )
+            },
+            "*Message*: \n*Details*:\n```\n\n```\n",
+        ),
+        ({"details": None}, "*Message*: \n*Details*: N/A\n"),
     ],
 )
 def test_format_search_results(data, expected_result):


### PR DESCRIPTION
This PR makes selecting and formatting the log details that come from the Search Results API more robust:

- Instead of assuming that the `outerMessage` and `details` columns will always be present in the full log details data, the [`select_search_results`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/azure_functions/function_app.py#L89) function now first determines which columns are available, thus avoiding an error if a column turns out not to be available.
- In the `dev` environment we noticed that for some alerts, `details` may turn out to be `None`, thus raising a `TypeError` from [`json.loads(details)`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/azure_functions/function_app.py#L121) in [`format_search_results`](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/blob/main/azure_functions/function_app.py#L108) which before we didn't catch, but now we do.
- We have added a few more tests to cover the situations described above.
