### PR TITLE
Refactor: use alternate alert management link

### DIFF
--- a/azure_functions/function_app.py
+++ b/azure_functions/function_app.py
@@ -30,7 +30,7 @@ def make_management_link(alert_id: str, resource_group: str, alert_target_ids: l
     """
     Generates an alert management link to the Azure Portal for the given alert.
     """
-    if "N/A" in (alert_id, resource_group, alert_target_ids):
+    if "N/A" in [alert_id, resource_group, *alert_target_ids]:
         return "#"
 
     base_url = "https://portal.azure.com/#view/Microsoft_Azure_Monitoring_Alerts/AlertDetails.ReactView/alertId~/"

--- a/tests/azure_functions/test_function_app.py
+++ b/tests/azure_functions/test_function_app.py
@@ -115,8 +115,10 @@ def test_format_item(key, value, expected_output):
                 "Microsoft.AlertsManagement%2Falerts%2F67890"
             ),
         ),
-        # Missing Data (N/A)
-        ("N/A", "rg-cdt-pub-vip-ddrc-d-001", ["N/A"], "#"),
+        # Missing Data (N/A in string)
+        ("N/A", "rg-cdt-pub-vip-ddrc-d-001", ["/subscriptions/12345"], "#"),
+        # Missing Data (N/A in list)
+        ("/subscriptions/12345/providers/Microsoft.AlertsManagement/alerts/67890", "rg-cdt-pub-vip-ddrc-d-001", ["N/A"], "#"),
         # Unexpected alert_target_ids
         (
             "/subscriptions/12345/providers/Microsoft.AlertsManagement/alerts/67890",


### PR DESCRIPTION
Originally we wanted to use the `investigationLink` field directly (available under the alert's `essentials` field) to manage Application Insights alerts, however, we ran into permissions problems when accessing the link:

> You need an Issue Contributor, Monitoring Contributor, or Contributor role to access this page. Contact your administrator to make sure you have the correct role.

The recommended permissions were added by DevSecOps but we still couldn't reach the page at `investigationLink`.

This PR replaces using `investigationLink` with a manually constructed link. The structure of the link was derived by looking at the `Copy link` feature of the Log search alert details:

<img width="3780" height="1204" alt="image" src="https://github.com/user-attachments/assets/b415d6c9-b150-4444-af5e-2e66ed8a2b23" />

It turns out that all the pieces needed to construct the link were available in different parts of the alert's JSON fields. And there were no permissions issues raised when accessing this constructed link.

The manually constructed link takes the user directly to the page shown above, but the `Log search alert details` pane is maximized to use the whole view. From here the alert can be managed more easily instead of having to filter and look for it in `Azure Monitor > Alerts`.

