### PR TITLE
Chore: bump Django from 5.2.7 to 5.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12"
 maintainers = [{ name = "Compiler LLC", email = "dev@compiler.la" }]
 dependencies = [
     "azure-monitor-opentelemetry==1.8.1",
-    "Django==5.2.7",
+    "Django==5.2.11",
     "django-azure-communication-email==1.6.0",
     "django-cdt-identity @ git+https://github.com/Office-of-Digital-Services/django-cdt-identity.git@c635773a75e7f184a9382748afcef6d5a705b2d6",
     "django-csp==3.8",


### PR DESCRIPTION
Addresses a number of [recently disclosed CVEs](https://github.com/Office-of-Digital-Services/cdt-ods-disaster-recovery/security/dependabot?q=is%3Aopen+manifest%3Apyproject.toml+package%3ADjango+) related to SQL injection.

Tested a Login.gov vital records request locally, the async task runner (email and pdf generation), and regular Django Admin tasks. 
